### PR TITLE
Remove unnecessary unsafe

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -945,7 +945,7 @@ fn parse_borrowed_str<'de>(
     let expected_start = expected_end.checked_sub(utf8_value.len())?;
     let borrowed_bytes = borrowed_repr.get(expected_start..expected_end)?;
     if borrowed_bytes == utf8_value.as_bytes() {
-        return Some(unsafe { str::from_utf8_unchecked(borrowed_bytes) });
+        return str::from_utf8(borrowed_bytes).ok();
     }
     None
 }


### PR DESCRIPTION
## Summary
- make `parse_borrowed_str` use safe UTF‑8 conversion

## Testing
- `cargo test --quiet` *(fails: failed to fetch `indexmap` because the crate index requires network access)*


------
https://chatgpt.com/codex/tasks/task_e_68691261c4fc832c941bfa6de9204f8d