### PR TITLE
Clean up unsafe conversions

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -945,7 +945,7 @@ fn parse_borrowed_str<'de>(
     let expected_start = expected_end.checked_sub(utf8_value.len())?;
     let borrowed_bytes = borrowed_repr.get(expected_start..expected_end)?;
     if borrowed_bytes == utf8_value.as_bytes() {
-        return Some(unsafe { str::from_utf8_unchecked(borrowed_bytes) });
+        return Some(str::from_utf8(borrowed_bytes).expect("validated utf-8"));
     }
     None
 }

--- a/src/libyaml/cstr.rs
+++ b/src/libyaml/cstr.rs
@@ -68,7 +68,7 @@ fn display_lossy(mut bytes: &[u8], formatter: &mut fmt::Formatter) -> fmt::Resul
             Ok(valid) => return formatter.write_str(valid),
             Err(utf8_error) => {
                 let valid_up_to = utf8_error.valid_up_to();
-                let valid = unsafe { str::from_utf8_unchecked(&bytes[..valid_up_to]) };
+                let valid = str::from_utf8(&bytes[..valid_up_to]).expect("valid utf-8 slice");
                 formatter.write_str(valid)?;
                 formatter.write_char(char::REPLACEMENT_CHARACTER)?;
                 if let Some(error_len) = utf8_error.error_len() {
@@ -90,7 +90,7 @@ pub(crate) fn debug_lossy(mut bytes: &[u8], formatter: &mut fmt::Formatter) -> f
             Ok(valid) => valid,
             Err(utf8_error) => {
                 let valid_up_to = utf8_error.valid_up_to();
-                unsafe { str::from_utf8_unchecked(&bytes[..valid_up_to]) }
+                str::from_utf8(&bytes[..valid_up_to]).expect("valid utf-8 slice")
             }
         };
 


### PR DESCRIPTION
## Summary
- remove `unsafe` conversion when parsing borrowed strings
- replace unchecked UTF-8 conversions in libyaml C string utilities with safe calls

## Testing
- `cargo test --quiet` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68691261c4fc832c941bfa6de9204f8d