### PR TITLE
remove unnecessary unsafe

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -10,8 +10,8 @@ use serde::de::Visitor;
 use serde::ser::{self, Serializer as _};
 use std::fmt::{self, Display};
 use std::io;
-use std::marker::PhantomData;
 use std::mem;
+
 use std::num;
 use std::str;
 
@@ -41,11 +41,10 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 ///     Ok(())
 /// }
 /// ```
-pub struct Serializer<W> {
+pub struct Serializer<W: io::Write> {
     depth: usize,
     state: State,
-    emitter: Emitter<'static>,
-    writer: PhantomData<W>,
+    emitter: Emitter<W>,
 }
 
 enum State {
@@ -62,16 +61,12 @@ where
 {
     /// Creates a new YAML serializer.
     pub fn new(writer: W) -> Result<Self> {
-        let mut emitter = Emitter::new({
-            let writer = Box::new(writer);
-            unsafe { mem::transmute::<Box<dyn io::Write>, Box<dyn io::Write>>(writer) }
-        })?;
+        let mut emitter = Emitter::new(Box::new(writer))?;
         emitter.emit(Event::StreamStart)?;
         Ok(Serializer {
             depth: 0,
             state: State::NothingInParticular,
             emitter,
-            writer: PhantomData,
         })
     }
 
@@ -87,7 +82,7 @@ where
         self.emitter.emit(Event::StreamEnd)?;
         self.emitter.flush()?;
         let writer = self.emitter.into_inner();
-        Ok(*unsafe { Box::from_raw(Box::into_raw(writer).cast::<W>()) })
+        Ok(*writer)
     }
 
     fn emit_scalar(&mut self, mut scalar: Scalar) -> Result<()> {


### PR DESCRIPTION
## Summary
- refactor `Emitter` and `Serializer` to avoid using `Box` pointer casts
- remove transmute and raw pointer conversions in serializer

## Testing
- `cargo check` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_68691261c4fc832c941bfa6de9204f8d