### PR TITLE
Preserve anchors and aliases in Value

### DIFF
--- a/tests/test_anchor_alias.rs
+++ b/tests/test_anchor_alias.rs
@@ -1,7 +1,7 @@
-use serde_yaml_bw::{from_str, to_string, Value};
+use serde_yaml_bw::{to_string, Value};
+use serde_yaml_bw::de::from_str_value_preserve;
 
 #[test]
-#[ignore]
 fn test_anchor_alias_roundtrip() {
     let yaml_input = r#"
 defaults: &defaults
@@ -18,7 +18,7 @@ production:
 "#;
 
     // Deserialize YAML with anchors and aliases
-    let parsed: Value = from_str(yaml_input).expect("Failed to parse YAML");
+    let parsed: Value = from_str_value_preserve(yaml_input).expect("Failed to parse YAML");
 
     // Serialize back to YAML
     let serialized = to_string(&parsed).expect("Failed to serialize YAML");


### PR DESCRIPTION
## Summary
- implement parsing helpers to keep anchor names and aliases
- expose `from_str_value_preserve` for reading `Value` with anchors
- use the new API in the anchor/alias round‑trip test

## Testing
- `cargo check`
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686c134337bc832c974ce76e0a7e4e4e