### PR TITLE
Fix merge precedence in apply_merge

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -722,7 +722,7 @@ impl Value {
                             }
                         }
                         Some(Value::Sequence(sequence)) => {
-                            for value in sequence {
+                            for value in sequence.into_iter().rev() {
                                 match value {
                                     Value::Mapping(merge) => {
                                         for (k, v) in merge {


### PR DESCRIPTION
## Summary
- ensure `Value::apply_merge` applies sequence merges in reverse order
- this lets later merge mappings override earlier ones

## Testing
- `cargo check --quiet`
- `cargo build --quiet`
- `cargo test --test test_merge_keys --quiet`
- `cargo test --quiet` *(fails: test_anchor_alias_roundtrip)*

`cargo fmt --all` failed due to missing component (blocked network access).

------
https://chatgpt.com/codex/tasks/task_e_686cd16cdf54832c8c9a4704bfe934ea