### PR TITLE
Add helper for merge-aware deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,8 @@ pub use crate::ser::{to_string, to_writer, Serializer};
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Number, Sequence, Value};
 
+use serde::de::DeserializeOwned;
+
 #[doc(inline)]
 pub use crate::mapping::Mapping;
 
@@ -180,6 +182,20 @@ mod path;
 mod ser;
 pub mod value;
 pub mod with;
+
+/// Deserialize YAML and apply YAML merge keys before converting to `T`.
+///
+/// This helper first parses the input into a [`Value`], performs
+/// [`Value::apply_merge`] to handle `<<` entries, and finally deserializes the
+/// merged value into the requested type.
+pub fn from_str_with_merge<'de, T>(s: &'de str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let mut value: Value = de::from_str(s)?;
+    value.apply_merge()?;
+    value::from_value(value)
+}
 
 // Prevent downstream code from implementing the Index trait.
 mod private {

--- a/tests/test_merge_keys_serde.rs
+++ b/tests/test_merge_keys_serde.rs
@@ -1,6 +1,5 @@
-use serde::Deserialize;
-use std::collections::HashMap;
 use serde_derive::Deserialize;
+use serde_yaml_bw::from_str_with_merge;
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Config {
@@ -16,7 +15,7 @@ struct Connection {
     database: Option<String>,
 }
 
-// #[test] // this test is currently failing
+#[test]
 fn test_anchor_alias_deserialization() {
     let yaml_input = r#"
 defaults: &defaults
@@ -32,8 +31,8 @@ production:
   database: prod_db
 "#;
 
-    // Deserialize YAML with anchors and aliases into the Config struct
-    let parsed: Config = serde_yaml::from_str(yaml_input).expect("Failed to deserialize YAML");
+    // Deserialize YAML with anchors, aliases and merge keys into the Config struct
+    let parsed: Config = from_str_with_merge(yaml_input).expect("Failed to deserialize YAML");
 
     // Define expected Config structure explicitly
     let expected = Config {


### PR DESCRIPTION
## Summary
- add `from_str_with_merge` helper for applying merge keys when deserializing
- enable merge key test by using the new helper

## Testing
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686d4dd009a8832caa71d1bba6af59e9