### PR TITLE
Add anchor deserialization test

### DIFF
--- a/tests/test_anchor_only.rs
+++ b/tests/test_anchor_only.rs
@@ -1,0 +1,35 @@
+use indoc::indoc;
+use serde_derive::Deserialize;
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct Node {
+    id: u32,
+    name: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct Root {
+    first: Node,
+    second: Node,
+}
+
+#[test]
+fn test_anchor_struct_deserialization() {
+    let yaml = indoc! {
+        "
+first: &node
+  id: 1
+  name: First
+second: *node
+"
+    };
+
+    let parsed: Root = serde_yaml_bw::from_str(yaml).expect("Failed to deserialize");
+    let expected = Root {
+        first: Node { id: 1, name: "First".into() },
+        second: Node { id: 1, name: "First".into() },
+    };
+
+    assert_eq!(parsed, expected);
+}
+


### PR DESCRIPTION
## Summary
- add a new test covering anchor alias deserialization for structs

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686e7ca3e4c4832ca37bdb03e979694b