### PR TITLE
Add tests for block scalars and support folded tags

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1289,7 +1289,7 @@ fn is_plain_or_tagged_literal_scalar(
 ) -> bool {
     match (scalar.style, &scalar.tag, tagged_already) {
         (ScalarStyle::Plain, _, _) => true,
-        (ScalarStyle::Literal, Some(tag), false) => tag == expected,
+        (ScalarStyle::Literal | ScalarStyle::Folded, Some(tag), false) => tag == expected,
         _ => false,
     }
 }

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -36,6 +36,36 @@ where
     assert!(deserializer.next().is_none());
 }
 
+#[test]
+fn test_folded_block_scalar_bool() {
+    let yaml = indoc! {"!!bool >-\n  true\n"};
+    test_de(yaml, &true);
+}
+
+#[test]
+fn test_folded_block_scalar_int() {
+    let yaml = indoc! {"!!int >-\n  42\n"};
+    test_de(yaml, &42_i32);
+}
+
+#[test]
+fn test_folded_block_scalar_float() {
+    let yaml = indoc! {"!!float >-\n  1.5\n"};
+    test_de(yaml, &1.5_f64);
+}
+
+#[test]
+fn test_folded_block_scalar_string() {
+    let yaml = ">-\n  folded\n  block\n";
+    test_de(yaml, &"folded block".to_owned());
+}
+
+#[test]
+fn test_literal_block_scalar_string() {
+    let yaml = "|-\n  literal\n  block\n";
+    test_de(yaml, &"literal\nblock".to_owned());
+}
+
 fn test_de_no_value<'de, T>(yaml: &'de str, expected: &T)
 where
     T: serde::de::Deserialize<'de> + PartialEq + Debug,


### PR DESCRIPTION
## Summary
- add new unit tests covering folded and literal block scalars
- allow typed folded scalars during deserialization
- run `cargo check` and `cargo test`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ed4f5f95c832c949feb9ecfa07e50