### PR TITLE
Add unit tests for YAML block scalars

### DIFF
--- a/tests/test_block_scalars.rs
+++ b/tests/test_block_scalars.rs
@@ -1,0 +1,42 @@
+#![allow(
+    clippy::derive_partial_eq_without_eq,
+    clippy::uninlined_format_args,
+)]
+
+use indoc::indoc;
+use serde_yaml_bw::Value;
+use std::collections::BTreeMap;
+
+#[test]
+fn test_block_scalars() {
+    let yaml = indoc! {
+        "
+        literal_clip: |
+          foo
+          bar
+        literal_strip: |-
+          foo
+          bar
+        literal_keep: |+
+          foo
+          bar
+
+        folded_clip: >
+          foo
+          bar
+        folded_strip: >-
+          foo
+          bar
+        folded_keep: >+
+          foo
+          bar
+        "
+    };
+    let data: BTreeMap<String, Value> = serde_yaml_bw::from_str(yaml).unwrap();
+    assert_eq!(data.get("literal_clip").unwrap(), "foo\nbar\n");
+    assert_eq!(data.get("literal_strip").unwrap(), "foo\nbar");
+    assert_eq!(data.get("literal_keep").unwrap(), "foo\nbar\n\n");
+    assert_eq!(data.get("folded_clip").unwrap(), "foo bar\n");
+    assert_eq!(data.get("folded_strip").unwrap(), "foo bar");
+    assert_eq!(data.get("folded_keep").unwrap(), "foo bar\n");
+}


### PR DESCRIPTION
## Summary
- add `test_block_scalars` covering literal (`|`, `|-`, `|+`) and folded (`>`, `>-`, `>+`) block styles

## Testing
- `cargo test --test test_block_scalars`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ed4f5f95c832c949feb9ecfa07e50