### PR TITLE
Enforce 'static writers in Serializer

### DIFF
--- a/src/with.rs
+++ b/src/with.rs
@@ -923,9 +923,9 @@ pub mod singleton_map {
 ///         bs: vec![Enum::Int(1)],
 ///     };
 ///
-///     let mut buf = Vec::new();
-///     let mut serializer = serde_yaml_bw::Serializer::new(&mut buf)?;
+///     let mut serializer = serde_yaml_bw::Serializer::new(Vec::new())?;
 ///     serde_yaml_bw::with::singleton_map_recursive::serialize(&object, &mut serializer).unwrap();
+///     let buf = serializer.into_inner()?;
 ///     io::stdout().write_all(&buf).unwrap();
 ///
 ///     let deserializer = serde_yaml_bw::Deserializer::from_slice(&buf);


### PR DESCRIPTION
## Summary
- require `io::Write + 'static` for `Serializer::new`
- remove transmute in favour of boxing the writer
- update all serializer trait impls and helper functions
- revise docs in `ser.rs` and `with.rs`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fa787d17c832ca254a8d1bfd0910d