### PR TITLE
Detect merge recursion

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,7 @@ pub(crate) enum ErrorImpl {
     TaggedInMerge,
     ScalarInMergeElement,
     SequenceInMergeElement,
+    MergeRecursion,
     EmptyTag,
     FailedToParseNumber,
     UnexpectedEndOfSequence,
@@ -263,6 +264,7 @@ impl ErrorImpl {
             ErrorImpl::SequenceInMergeElement => {
                 f.write_str("expected a mapping for merging, but found sequence")
             }
+            ErrorImpl::MergeRecursion => f.write_str("encountered recursive merge alias"),
             ErrorImpl::EmptyTag => f.write_str("empty YAML tag is not allowed"),
             ErrorImpl::FailedToParseNumber => f.write_str("failed to parse YAML number"),
             ErrorImpl::Shared(err) => err.display(f),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -710,9 +710,15 @@ impl Value {
     /// assert_eq!(value["tasks"]["start"]["args"], "start");
     /// ```
     pub fn apply_merge(&mut self) -> Result<(), Error> {
+        use std::collections::HashSet;
         let mut stack = Vec::new();
+        let mut visited = HashSet::new();
         stack.push(self);
         while let Some(node) = stack.pop() {
+            let ptr = node as *const Value as usize;
+            if !visited.insert(ptr) {
+                return Err(error::new(ErrorImpl::MergeRecursion));
+            }
             match node {
                 Value::Mapping(mapping) => {
                     match mapping.remove("<<") {

--- a/tests/test_merge_cycle.rs
+++ b/tests/test_merge_cycle.rs
@@ -1,0 +1,8 @@
+use serde_yaml_bw::{Value, from_str_value_preserve};
+
+#[test]
+fn test_self_referential_merge_alias_error() {
+    let yaml = "a: &a\n  b: 1\n  <<: *a";
+    let mut value = from_str_value_preserve(yaml).unwrap();
+    assert!(value.apply_merge().is_err());
+}


### PR DESCRIPTION
## Summary
- add `MergeRecursion` error variant
- detect repeated nodes in `Value::apply_merge`
- test self-referential merge alias handling

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fa791bdd0832c90a6e326b27367e6