### PR TITLE
Add cargo audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo generate-lockfile -Z minimal-versions
       - run: cargo check --locked
+
+  audit:
+    name: Cargo Audit
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+      - name: Run cargo audit
+        run: cargo audit


### PR DESCRIPTION
## Summary
- add a new `audit` job in CI that installs and runs `cargo audit`

## Testing
- `cargo check`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686fa84540d4832c98494cc7cdd0bc28