### PR TITLE
Add regression test for Serializer::new

### DIFF
--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -579,3 +579,15 @@ fn test_long_string() {
 
     test_serde(&thing, yaml);
 }
+
+#[test]
+fn test_serializer_into_vec() {
+    use serde::Serialize as _;
+
+    let mut buffer = Vec::new();
+    {
+        let mut ser = serde_yaml_bw::Serializer::new(&mut buffer).unwrap();
+        "hi".serialize(&mut ser).unwrap();
+    }
+    assert_eq!(buffer, b"hi\n");
+}


### PR DESCRIPTION
## Summary
- verify that `Serializer::new` works with non-`'static` writers

## Testing
- `cargo check`
- `cargo build`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686fa7bc6ec4832c8513fc895b6445de