### PR TITLE
Fix writer initialization

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -27,8 +27,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// use std::collections::BTreeMap;
 ///
 /// fn main() -> Result<()> {
-///     let mut buffer = Vec::new();
-///     let mut ser = serde_yaml_bw::Serializer::new(&mut buffer)?;
+///     let mut ser = serde_yaml_bw::Serializer::new(Vec::new())?;
 ///
 ///     let mut object = BTreeMap::new();
 ///     object.insert("k", 107);
@@ -37,6 +36,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 ///     object.insert("J", 74);
 ///     object.serialize(&mut ser)?;
 ///
+///     let buffer = ser.into_inner()?;
 ///     assert_eq!(buffer, b"k: 107\n---\nJ: 74\nk: 107\n");
 ///     Ok(())
 /// }
@@ -58,13 +58,13 @@ enum State {
 
 impl<W> Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     /// Creates a new YAML serializer.
     pub fn new(writer: W) -> Result<Self> {
         let mut emitter = Emitter::new({
-            let writer = Box::new(writer);
-            unsafe { mem::transmute::<Box<dyn io::Write>, Box<dyn io::Write>>(writer) }
+            let writer: Box<dyn io::Write> = Box::new(writer);
+            writer
         })?;
         emitter.emit(Event::StreamStart)?;
         Ok(Serializer {
@@ -168,7 +168,7 @@ where
 
 impl<'a, W> ser::Serializer for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -526,7 +526,7 @@ where
 
 impl<'a, W> ser::SerializeSeq for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -545,7 +545,7 @@ where
 
 impl<'a, W> ser::SerializeTuple for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -564,7 +564,7 @@ where
 
 impl<'a, W> ser::SerializeTupleStruct for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -583,7 +583,7 @@ where
 
 impl<'a, W> ser::SerializeTupleVariant for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -602,7 +602,7 @@ where
 
 impl<'a, W> ser::SerializeMap for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -650,7 +650,7 @@ where
 
 impl<'a, W> ser::SerializeStruct for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -670,7 +670,7 @@ where
 
 impl<'a, W> ser::SerializeStructVariant for &'a mut Serializer<W>
 where
-    W: io::Write,
+    W: io::Write + 'static,
 {
     type Ok = ();
     type Error = Error;
@@ -694,7 +694,7 @@ where
 /// return an error.
 pub fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
 where
-    W: io::Write,
+    W: io::Write + 'static,
     T: ?Sized + ser::Serialize,
 {
     let mut serializer = Serializer::new(writer)?;
@@ -709,7 +709,8 @@ pub fn to_string<T>(value: &T) -> Result<String>
 where
     T: ?Sized + ser::Serialize,
 {
-    let mut vec = Vec::with_capacity(128);
-    to_writer(&mut vec, value)?;
+    let mut serializer = Serializer::new(Vec::with_capacity(128))?;
+    value.serialize(&mut serializer)?;
+    let vec = serializer.into_inner()?;
     String::from_utf8(vec).map_err(|error| error::new(ErrorImpl::FromUtf8(error)))
 }

--- a/src/with.rs
+++ b/src/with.rs
@@ -923,9 +923,9 @@ pub mod singleton_map {
 ///         bs: vec![Enum::Int(1)],
 ///     };
 ///
-///     let mut buf = Vec::new();
-///     let mut serializer = serde_yaml_bw::Serializer::new(&mut buf)?;
+///     let mut serializer = serde_yaml_bw::Serializer::new(Vec::new())?;
 ///     serde_yaml_bw::with::singleton_map_recursive::serialize(&object, &mut serializer).unwrap();
+///     let buf = serializer.into_inner()?;
 ///     io::stdout().write_all(&buf).unwrap();
 ///
 ///     let deserializer = serde_yaml_bw::Deserializer::from_slice(&buf);


### PR DESCRIPTION
## Summary
- avoid `mem::transmute` in `Serializer::new`
- adjust docs and helper functions for the `'static` writer requirement

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fa7542680832c8467947845d7c12a