### PR TITLE
Revert "Enforce 'static writers in Serializer"

### DIFF
--- a/src/with.rs
+++ b/src/with.rs
@@ -923,9 +923,9 @@ pub mod singleton_map {
 ///         bs: vec![Enum::Int(1)],
 ///     };
 ///
-///     let mut serializer = serde_yaml_bw::Serializer::new(Vec::new())?;
+///     let mut buf = Vec::new();
+///     let mut serializer = serde_yaml_bw::Serializer::new(&mut buf)?;
 ///     serde_yaml_bw::with::singleton_map_recursive::serialize(&object, &mut serializer).unwrap();
-///     let buf = serializer.into_inner()?;
 ///     io::stdout().write_all(&buf).unwrap();
 ///
 ///     let deserializer = serde_yaml_bw::Deserializer::from_slice(&buf);


### PR DESCRIPTION
This breaks usability of the library, cannot be "fixed" like this