### PR TITLE
Address some Clippy warnings

### DIFF
--- a/src/duplicate_key.rs
+++ b/src/duplicate_key.rs
@@ -18,7 +18,7 @@ pub(crate) struct DuplicateKeyError {
 
 impl DuplicateKeyError {
     pub(crate) fn from_value(value: &Value) -> Self {
-        use DuplicateKeyKind::*;
+        use DuplicateKeyKind::{Bool, Null, Number, Other, String};
         let kind = match value {
             Value::Null(_) => Null,
             Value::Bool(b, _) => Bool(*b),
@@ -30,7 +30,7 @@ impl DuplicateKeyError {
     }
 
     pub(crate) fn from_scalar(bytes: &[u8]) -> Self {
-        use DuplicateKeyKind::*;
+        use DuplicateKeyKind::{Bool, Null, Number, Other, String};
         if is_null(bytes) {
             return DuplicateKeyError { kind: Null };
         }
@@ -61,7 +61,7 @@ fn parse_bool(s: &str) -> Option<bool> {
 
 impl Display for DuplicateKeyError {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        use DuplicateKeyKind::*;
+        use DuplicateKeyKind::{Bool, Null, Number, Other, String};
         formatter.write_str("duplicate entry ")?;
         match &self.kind {
             Null => formatter.write_str("with null key"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -299,7 +299,7 @@ impl ErrorImpl {
             _ => {
                 f.write_str("Error(")?;
                 struct MessageNoMark<'a>(&'a ErrorImpl);
-                impl<'a> Display for MessageNoMark<'a> {
+                impl Display for MessageNoMark<'_> {
                     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                         self.0.message_no_mark(f)
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,5 +188,5 @@ mod private {
     impl Sealed for str {}
     impl Sealed for String {}
     impl Sealed for crate::Value {}
-    impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
+    impl<T> Sealed for &T where T: ?Sized + Sealed {}
 }

--- a/src/libyaml/cstr.rs
+++ b/src/libyaml/cstr.rs
@@ -10,8 +10,8 @@ pub(crate) struct CStr<'a> {
     marker: PhantomData<&'a [u8]>,
 }
 
-unsafe impl<'a> Send for CStr<'a> {}
-unsafe impl<'a> Sync for CStr<'a> {}
+unsafe impl Send for CStr<'_> {}
+unsafe impl Sync for CStr<'_> {}
 
 impl<'a> CStr<'a> {
     pub fn from_bytes_with_nul(bytes: &'static [u8]) -> Self {
@@ -44,7 +44,7 @@ impl<'a> CStr<'a> {
     }
 }
 
-impl<'a> Display for CStr<'a> {
+impl Display for CStr<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let ptr = self.ptr.as_ptr();
         let len = self.len();
@@ -53,7 +53,7 @@ impl<'a> Display for CStr<'a> {
     }
 }
 
-impl<'a> Debug for CStr<'a> {
+impl Debug for CStr<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let ptr = self.ptr.as_ptr();
         let len = self.len();

--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -190,7 +190,7 @@ impl<'a> Emitter<'a> {
         if let Some(write_error) = emitter.write_error.take() {
             Error::Io(write_error)
         } else {
-            Error::Libyaml(unsafe { libyaml::Error::emit_error(&emitter.sys) })
+            Error::Libyaml(unsafe { libyaml::Error::emit_error(&raw const emitter.sys) })
         }
     }
 }
@@ -210,8 +210,8 @@ unsafe fn write_handler(data: *mut c_void, buffer: *mut u8, size: u64) -> i32 {
     }
 }
 
-impl<'a> Drop for EmitterPinned<'a> {
+impl Drop for EmitterPinned<'_> {
     fn drop(&mut self) {
-        unsafe { sys::yaml_emitter_delete(&mut self.sys) }
+        unsafe { sys::yaml_emitter_delete(&raw mut self.sys) }
     }
 }

--- a/src/libyaml/error.rs
+++ b/src/libyaml/error.rs
@@ -18,29 +18,29 @@ pub(crate) struct Error {
 impl Error {
     pub unsafe fn parse_error(parser: *const sys::yaml_parser_t) -> Self {
         Error {
-            kind: unsafe { (&(*parser)).error },
-            problem: match NonNull::new(unsafe { (&(*parser)).problem as *mut _ }) {
+            kind: unsafe { (*parser).error },
+            problem: match NonNull::new(unsafe { (*parser).problem.cast_mut() }) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => CStr::from_bytes_with_nul(b"libyaml parser failed but there is no error\0"),
             },
-            problem_offset: unsafe { (&(*parser)).problem_offset },
+            problem_offset: unsafe { (*parser).problem_offset },
             problem_mark: Mark {
-                sys: unsafe { (&(*parser)).problem_mark },
+                sys: unsafe { (*parser).problem_mark },
             },
-            context: match NonNull::new(unsafe { (&(*parser)).context as *mut _ }) {
+            context: match NonNull::new(unsafe { (*parser).context.cast_mut() }) {
                 Some(context) => Some(unsafe { CStr::from_ptr(context) }),
                 None => None,
             },
             context_mark: Mark {
-                sys: unsafe { (&(*parser)).context_mark },
+                sys: unsafe { (*parser).context_mark },
             },
         }
     }
 
     pub unsafe fn emit_error(emitter: *const sys::yaml_emitter_t) -> Self {
         Error {
-            kind: unsafe { (&(*emitter)).error },
-            problem: match NonNull::new(unsafe { (&(*emitter)).problem as *mut _ }) {
+            kind: unsafe { (*emitter).error },
+            problem: match NonNull::new(unsafe { (*emitter).problem.cast_mut() }) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => {
                     CStr::from_bytes_with_nul(b"libyaml emitter failed but there is no error\0")

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -47,9 +47,8 @@ impl<'input> Loader<'input> {
     }
 
     pub fn next_document(&mut self) -> Option<Document<'input>> {
-        let parser = match &mut self.parser {
-            Some(parser) => parser,
-            None => return None,
+        let Some(parser) = &mut self.parser else {
+            return None;
         };
 
         let first = self.document_count == 0;

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -273,7 +273,7 @@ pub trait Index: private::Sealed {
 
 struct HashLikeValue<'a>(&'a str);
 
-impl<'a> indexmap::Equivalent<Value> for HashLikeValue<'a> {
+impl indexmap::Equivalent<Value> for HashLikeValue<'_> {
     fn equivalent(&self, key: &Value) -> bool {
         match key {
             Value::String(string, _) => self.0 == string,
@@ -283,7 +283,7 @@ impl<'a> indexmap::Equivalent<Value> for HashLikeValue<'a> {
 }
 
 // NOTE: This impl must be consistent with Value's Hash impl.
-impl<'a> Hash for HashLikeValue<'a> {
+impl Hash for HashLikeValue<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         const STRING: Value = Value::String(String::new(), None);
         mem::discriminant(&STRING).hash(state);

--- a/src/number.rs
+++ b/src/number.rs
@@ -287,7 +287,7 @@ impl Serialize for Number {
 
 struct NumberVisitor;
 
-impl<'de> Visitor<'de> for NumberVisitor {
+impl Visitor<'_> for NumberVisitor {
     type Value = Number;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -342,7 +342,7 @@ impl<'de> Deserializer<'de> for Number {
     }
 }
 
-impl<'de, 'a> Deserializer<'de> for &'a Number {
+impl<'de> Deserializer<'de> for &Number {
     type Error = Error;
 
     #[inline]

--- a/src/path.rs
+++ b/src/path.rs
@@ -10,11 +10,11 @@ pub enum Path<'a> {
     Unknown { parent: &'a Path<'a> },
 }
 
-impl<'a> Display for Path<'a> {
+impl Display for Path<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         struct Parent<'a>(&'a Path<'a>);
 
-        impl<'a> Display for Parent<'a> {
+        impl Display for Parent<'_> {
             fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
                 match self.0 {
                     Path::Root => Ok(()),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -164,7 +164,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::Serializer for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::Serializer for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {
@@ -306,7 +306,7 @@ where
     fn serialize_str(self, value: &str) -> Result<()> {
         struct InferScalarStyle;
 
-        impl<'de> Visitor<'de> for InferScalarStyle {
+        impl Visitor<'_> for InferScalarStyle {
             type Value = ScalarStyle;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -522,7 +522,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::SerializeSeq for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::SerializeSeq for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {
@@ -541,7 +541,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::SerializeTuple for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::SerializeTuple for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {
@@ -560,7 +560,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::SerializeTupleStruct for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::SerializeTupleStruct for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {
@@ -579,7 +579,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::SerializeTupleVariant for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::SerializeTupleVariant for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {
@@ -598,7 +598,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::SerializeMap for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::SerializeMap for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {
@@ -646,7 +646,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::SerializeStruct for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::SerializeStruct for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {
@@ -666,7 +666,7 @@ where
     }
 }
 
-impl<'ser, 'a, W> ser::SerializeStructVariant for &'ser mut Serializer<'a, W>
+impl<'a, W> ser::SerializeStructVariant for &mut Serializer<'a, W>
 where
     W: io::Write + 'a,
 {

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -496,7 +496,7 @@ struct EnumDeserializer<'a> {
     value: Option<Value>,
 }
 
-impl<'a, 'de> EnumAccess<'de> for EnumDeserializer<'a> {
+impl<'de> EnumAccess<'de> for EnumDeserializer<'_> {
     type Error = Error;
     type Variant = VariantDeserializer;
 

--- a/src/value/debug.rs
+++ b/src/value/debug.rs
@@ -22,7 +22,7 @@ impl Debug for Value {
 
 struct DisplayNumber<'a>(&'a Number);
 
-impl<'a> Debug for DisplayNumber<'a> {
+impl Debug for DisplayNumber<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(self.0, formatter)
     }

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -53,7 +53,7 @@ impl From<String> for Value {
     }
 }
 
-impl<'a> From<&'a str> for Value {
+impl From<&str> for Value {
     /// Convert string slice to `Value`
     ///
     /// # Examples

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -50,7 +50,7 @@ impl Index for String {
     }
 }
 
-impl<'a, T> Index for &'a T
+impl<T> Index for &T
 where
     T: ?Sized + Index,
 {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -715,7 +715,7 @@ impl Value {
         let mut visited = HashSet::new();
         stack.push(self);
         while let Some(node) = stack.pop() {
-            let ptr = node as *const Value as usize;
+            let ptr = std::ptr::from_ref::<Value>(node) as usize;
             if !visited.insert(ptr) {
                 return Err(error::new(ErrorImpl::MergeRecursion));
             }
@@ -782,7 +782,7 @@ impl Hash for Value {
     }
 }
 
-impl<'de> IntoDeserializer<'de, Error> for Value {
+impl IntoDeserializer<'_, Error> for Value {
     type Deserializer = Self;
 
     fn into_deserializer(self) -> Self::Deserializer {

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -10,11 +10,11 @@ impl PartialEq<str> for Value {
     /// assert!(Value::String("lorem".into(), None) == *"lorem");
     /// ```
     fn eq(&self, other: &str) -> bool {
-        self.as_str().map_or(false, |s| s == other)
+        self.as_str() == Some(other)
     }
 }
 
-impl<'a> PartialEq<&'a str> for Value {
+impl PartialEq<&str> for Value {
     /// Compare `&str` with YAML value
     ///
     /// # Examples
@@ -24,7 +24,7 @@ impl<'a> PartialEq<&'a str> for Value {
     /// assert!(Value::String("lorem".into(), None) == "lorem");
     /// ```
     fn eq(&self, other: &&str) -> bool {
-        self.as_str().map_or(false, |s| s == *other)
+        self.as_str() == Some(*other)
     }
 }
 
@@ -38,7 +38,7 @@ impl PartialEq<String> for Value {
     /// assert!(Value::String("lorem".into(), None) == "lorem".to_string());
     /// ```
     fn eq(&self, other: &String) -> bool {
-        self.as_str().map_or(false, |s| s == other)
+        self.as_str() == Some(other.as_str())
     }
 }
 
@@ -52,7 +52,7 @@ impl PartialEq<bool> for Value {
     /// assert!(Value::Bool(true, None) == true);
     /// ```
     fn eq(&self, other: &bool) -> bool {
-        self.as_bool().map_or(false, |b| b == *other)
+        self.as_bool() == Some(*other)
     }
 }
 

--- a/src/value/tagged.rs
+++ b/src/value/tagged.rs
@@ -178,7 +178,7 @@ impl Serialize for TaggedValue {
     {
         struct SerializeTag<'a>(&'a Tag);
 
-        impl<'a> Serialize for SerializeTag<'a> {
+        impl Serialize for SerializeTag<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: Serializer,
@@ -382,7 +382,7 @@ impl<'de> VariantAccess<'de> for &'de Value {
 
 pub(crate) struct TagStringVisitor;
 
-impl<'de> Visitor<'de> for TagStringVisitor {
+impl Visitor<'_> for TagStringVisitor {
     type Value = Tag;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -466,9 +466,9 @@ where
 
     let mut check_for_tag = CheckForTag::Empty;
     match fmt::write(&mut check_for_tag, format_args!("{}", value)) {
-        Ok(_) => {},
-        Err(_) => return MaybeTag::Error
-    };
+        Ok(()) => {}
+        Err(_) => return MaybeTag::Error,
+    }
     
     match check_for_tag {
         CheckForTag::Empty => MaybeTag::NotTag(String::new()),

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -503,7 +503,7 @@ fn test_stateful() {
             D: serde::de::Deserializer<'de>,
         {
             struct Visitor(i64);
-            impl<'de> serde::de::Visitor<'de> for Visitor {
+            impl serde::de::Visitor<'_> for Visitor {
                 type Value = i64;
 
                 fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/tests/test_historical_failures.rs
+++ b/tests/test_historical_failures.rs
@@ -39,10 +39,10 @@ fn test_custom_yaml_tags() {
                 serde_yaml_bw::Value::Mapping(map) => {
                     assert!(map.contains_key(&serde_yaml_bw::Value::String("key".into(), None)));
                 }
-                other => panic!("Expected mapping inside tag, got: {:?}", other),
+                other => panic!("Expected mapping inside tag, got: {other:?}"),
             }
         }
-        other => panic!("Expected TaggedValue, got: {:?}", other),
+        other => panic!("Expected TaggedValue, got: {other:?}"),
     }
 }
 

--- a/tests/test_merge_keys_values.rs
+++ b/tests/test_merge_keys_values.rs
@@ -40,8 +40,14 @@ fn assert_same_entries(a: &Value, b: &Value) {
     for a_key in a.keys() {
         assert!(b.contains_key(a_key));
         let key = a_key.as_str();
-        let a_value = a.get(a_key).unwrap_or_else(|| panic!("key not present in a: {:?}", key)).as_str();
-        let b_value = b.get(a_key).unwrap_or_else(|| panic!("key not present in b: {:?}", key)).as_str();
+        let a_value = a
+            .get(a_key)
+            .unwrap_or_else(|| panic!("key not present in a: {key:?}"))
+            .as_str();
+        let b_value = b
+            .get(a_key)
+            .unwrap_or_else(|| panic!("key not present in b: {key:?}"))
+            .as_str();
 
         assert_eq!(
             a_value, b_value,

--- a/tests/test_merge_keys_values.rs
+++ b/tests/test_merge_keys_values.rs
@@ -2,7 +2,7 @@ use serde_yaml_bw::{to_string, Value, from_str_value_preserve};
 
 #[test]
 fn test_field_inheritance() {
-    let yaml_input = r#"
+    let yaml_input = r"
 defaults: &defaults
   adapter: postgres
   host: localhost
@@ -14,7 +14,7 @@ development:
 production:
   <<: *defaults
   database: prod_db
-"#;
+";
 
     // Deserialize YAML with anchors and aliases
     let parsed: Value = from_str_value_preserve(yaml_input).expect("Failed to parse YAML");
@@ -22,7 +22,7 @@ production:
     // Serialize back to YAML
     let serialized = to_string(&parsed).expect("Failed to serialize YAML");
 
-    println!("Serialized output:\n{}", serialized);
+    println!("Serialized output:\n{serialized}");
 
     // Verify anchor/alias roundtrip (anchors preserved, aliases not expanded)
     assert!(
@@ -53,7 +53,7 @@ fn assert_same_entries(a: &Value, b: &Value) {
 
 #[test]
 fn test_merge_key_example() {
-    let yaml = r#"
+    let yaml = r"
 - &CENTER { x: 1, y: 2 }
 - &LEFT { x: 0, y: 2 }
 - &BIG { r: 10 }
@@ -74,7 +74,7 @@ fn test_merge_key_example() {
 # And here we have it all:
 - <<: [ *BIG, *LEFT, { x: 1, y: 2 } ]
   label: center/big
-"#;
+";
 
     let value: Value = serde_yaml_bw::from_str(yaml).unwrap();
 

--- a/tests/test_no_panic.rs
+++ b/tests/test_no_panic.rs
@@ -20,7 +20,7 @@ fn test_yaml_malformed() {
     let yaml_input = "\n    x {\n        ";
 
     let result: Result<TestStruct, _> = serde_yaml_bw::from_str(yaml_input);
-    println!("{:?}", result);
+    println!("{result:?}");
 
     // Confirm parsing yields an error, and does not panic or succeed.
     assert!(result.is_err(), "Parsing invalid YAML should fail with an error, not succeed.");


### PR DESCRIPTION
## Summary
- fix Clippy lints across src and tests
- clean up raw string literals in tests
- simplify Option handling and lifetime elision
- adjust test formatting

## Testing
- `cargo check`
- `cargo test`
- `cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic` *(fails: format_push_string, uninlined_format_args)*

------
https://chatgpt.com/codex/tasks/task_e_686fcf7a3608832cb85f03fe38fe65bb