### PR TITLE
Fix raw pointer autoref warnings

### DIFF
--- a/src/libyaml/error.rs
+++ b/src/libyaml/error.rs
@@ -18,29 +18,29 @@ pub(crate) struct Error {
 impl Error {
     pub unsafe fn parse_error(parser: *const sys::yaml_parser_t) -> Self {
         Error {
-            kind: unsafe { (*parser).error },
-            problem: match NonNull::new(unsafe { (*parser).problem.cast_mut() }) {
+            kind: unsafe { (&*parser).error },
+            problem: match NonNull::new(unsafe { (&*parser).problem.cast_mut() }) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => CStr::from_bytes_with_nul(b"libyaml parser failed but there is no error\0"),
             },
-            problem_offset: unsafe { (*parser).problem_offset },
+            problem_offset: unsafe { (&*parser).problem_offset },
             problem_mark: Mark {
-                sys: unsafe { (*parser).problem_mark },
+                sys: unsafe { (&*parser).problem_mark },
             },
-            context: match NonNull::new(unsafe { (*parser).context.cast_mut() }) {
+            context: match NonNull::new(unsafe { (&*parser).context.cast_mut() }) {
                 Some(context) => Some(unsafe { CStr::from_ptr(context) }),
                 None => None,
             },
             context_mark: Mark {
-                sys: unsafe { (*parser).context_mark },
+                sys: unsafe { (&*parser).context_mark },
             },
         }
     }
 
     pub unsafe fn emit_error(emitter: *const sys::yaml_emitter_t) -> Self {
         Error {
-            kind: unsafe { (*emitter).error },
-            problem: match NonNull::new(unsafe { (*emitter).problem.cast_mut() }) {
+            kind: unsafe { (&*emitter).error },
+            problem: match NonNull::new(unsafe { (&*emitter).problem.cast_mut() }) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => {
                     CStr::from_bytes_with_nul(b"libyaml emitter failed but there is no error\0")

--- a/src/libyaml/parser.rs
+++ b/src/libyaml/parser.rs
@@ -86,7 +86,7 @@ impl<'input> Parser<'input> {
         let mut event = MaybeUninit::<sys::yaml_event_t>::uninit();
         unsafe {
             let parser = addr_of_mut!((*self.pin.ptr).sys);
-            if (*parser).error != sys::YAML_NO_ERROR {
+            if (&*parser).error != sys::YAML_NO_ERROR {
                 return Err(Error::parse_error(parser));
             }
             let event = event.as_mut_ptr();


### PR DESCRIPTION
## Summary
- handle raw pointer fields using explicit references

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686fe2ccb244832ca78511594f35da2a