### PR TITLE
Restrict CStr Send/Sync to 'static

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Since the API has changed to a more restrictive version, the major version numbe
 
 If a panic does occur under some short and clear input, please report it as a bug.
 
+### Thread Safety
+
+Internally the library uses a `CStr` wrapper for libyaml strings. This type is
+`Send` and `Sync` only when referencing data that lives for the `'static`
+lifetime, so short-lived pointers returned by the parser must not be shared
+across threads.
+
 
 ## Usage Example
 


### PR DESCRIPTION
## Summary
- document thread-safety in README
- limit `Send` and `Sync` implementations for `CStr` to `'static` lifetimes
- add comments describing why this is safe
- test that `CStr<'static>` can be moved across threads

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fed748080832c92f86245dc79195c