### PR TITLE
Fix parser event cleanup and add regression test

### DIFF
--- a/src/libyaml/parser.rs
+++ b/src/libyaml/parser.rs
@@ -91,6 +91,7 @@ impl<'input> Parser<'input> {
             }
             let event = event.as_mut_ptr();
             if sys::yaml_parser_parse(parser, event).fail {
+                sys::yaml_event_delete(event);
                 return Err(Error::parse_error(parser));
             }
             let ret = convert_event(&*event, &(*self.pin.ptr).input);
@@ -202,5 +203,25 @@ impl Debug for Anchor {
 impl Drop for ParserPinned<'_> {
     fn drop(&mut self) {
         unsafe { sys::yaml_parser_delete(&raw mut self.sys) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn repeated_parse_errors_do_not_leak() {
+        let yaml = ":";
+        for _ in 0..100 {
+            let mut parser = Parser::new(Cow::Borrowed(yaml.as_bytes())).unwrap();
+            loop {
+                match parser.next() {
+                    Ok(_) => continue,
+                    Err(_) => break,
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- fix memory leak in `Parser::next` by deleting the event on parse failure
- add a regression test covering repeated parse failures

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68702d59933c832c9174557eed7d8dc6