### PR TITLE
Add invalid anchor error test

### DIFF
--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -121,6 +121,19 @@ fn test_ignored_unknown_anchor() {
 }
 
 #[test]
+fn test_invalid_anchor_reference_message() {
+    let yaml = "*invalid_anchor";
+    let result: Result<Value, _> = serde_yaml_bw::from_str(yaml);
+    match result {
+        Ok(_) => panic!("Expected error for invalid anchor"),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(msg.contains("invalid_anchor"), "Unexpected error: {}", msg);
+        }
+    }
+}
+
+#[test]
 fn test_bytes() {
     let expected = "serialization and deserialization of bytes in YAML is not implemented";
     test_error::<&[u8]>("...", expected);


### PR DESCRIPTION
## Summary
- add a malformed anchor alias YAML case
- test that deserialization surfaces an error containing `invalid_anchor`

## Testing
- `cargo check`
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68702d873f84832cae5f847f1d6cc435