### PR TITLE
Add stable ids for merge cycle detection

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -728,7 +728,7 @@ impl<'de, 'document> DeserializerFromEvents<'de, 'document> {
                     elements.push(self.parse_value()?);
                 }
                 self.next_event()?; // consume SequenceEnd
-                Ok(Value::Sequence(Sequence { anchor, elements }))
+                Ok(Value::Sequence(Sequence { anchor, elements, id: crate::value::next_id() }))
             }
             MappingStart(map) => {
                 let anchor = map.anchor.clone();

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -11,12 +11,32 @@ use std::hash::{Hash, Hasher};
 use std::mem;
 
 /// A YAML mapping in which the keys and values are both `serde_yaml_bw::Value`.
-#[derive(Clone, Default, Eq, PartialEq)]
+#[derive(Clone)]
 pub struct Mapping {
     /// Optional anchor associated with this mapping.
     pub anchor: Option<String>,
     map: IndexMap<Value, Value>,
+    #[doc(hidden)]
+    pub id: usize,
 }
+
+impl Default for Mapping {
+    fn default() -> Self {
+        Mapping {
+            anchor: None,
+            map: IndexMap::new(),
+            id: crate::value::next_id(),
+        }
+    }
+}
+
+impl PartialEq for Mapping {
+    fn eq(&self, other: &Self) -> bool {
+        self.anchor == other.anchor && self.map == other.map
+    }
+}
+
+impl Eq for Mapping {}
 
 impl Mapping {
     /// Creates an empty YAML map.
@@ -25,6 +45,7 @@ impl Mapping {
         Mapping {
             anchor: None,
             map: IndexMap::new(),
+            id: crate::value::next_id(),
         }
     }
 
@@ -34,6 +55,7 @@ impl Mapping {
         Mapping {
             anchor: None,
             map: IndexMap::with_capacity(capacity),
+            id: crate::value::next_id(),
         }
     }
 
@@ -520,6 +542,7 @@ impl FromIterator<(Value, Value)> for Mapping {
         Mapping {
             anchor: None,
             map: IndexMap::from_iter(iter),
+            id: crate::value::next_id(),
         }
     }
 }

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -17,7 +17,7 @@ pub struct Mapping {
     pub anchor: Option<String>,
     map: IndexMap<Value, Value>,
     #[doc(hidden)]
-    pub id: usize,
+    pub(crate) id: usize,
 }
 
 impl Default for Mapping {

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -910,7 +910,7 @@ impl<'de> Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        static EMPTY: Sequence = Sequence::new();
+        static EMPTY: Sequence = Sequence::const_new();
         match self.untag_ref() {
             Value::Sequence(v) => visit_sequence_ref(v, visitor),
             Value::Null(_) => visit_sequence_ref(&EMPTY, visitor),

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -128,6 +128,7 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
         Value::Sequence(Sequence {
             anchor: None,
             elements: f.into_iter().map(Into::into).collect(),
+            id: crate::value::next_id(),
         })
     }
 }
@@ -147,6 +148,7 @@ impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
         Value::Sequence(Sequence {
             anchor: None,
             elements: f.iter().cloned().map(Into::into).collect(),
+            id: crate::value::next_id(),
         })
     }
 }
@@ -182,6 +184,7 @@ impl<T: Into<Value>> FromIterator<T> for Value {
         Value::Sequence(Sequence {
             anchor: None,
             elements: vec,
+            id: crate::value::next_id(),
         })
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -95,7 +95,7 @@ pub struct Sequence {
     /// Elements of the YAML sequence.
     pub elements: Vec<Value>,
     #[doc(hidden)]
-    pub id: usize,
+    pub(crate) id: usize,
 }
 
 impl Default for Sequence {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod tagged;
 use crate::error::{self, Error, ErrorImpl};
 use serde::de::{Deserialize, DeserializeOwned, IntoDeserializer};
 use serde::Serialize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::hash::{Hash, Hasher};
 use std::mem;
 
@@ -20,6 +21,12 @@ pub use self::tagged::{Tag, TaggedValue};
 #[doc(inline)]
 pub use crate::mapping::Mapping;
 pub use crate::number::Number;
+
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+pub(crate) fn next_id() -> usize {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 /// Represents any valid YAML value or in some cases error
 #[derive(Clone, PartialEq, PartialOrd)]
@@ -81,12 +88,48 @@ impl Default for Value {
 }
 
 /// A YAML sequence in which the elements are `serde_yaml_bw::Value`.
-#[derive(Clone, Default, PartialEq, PartialOrd, Eq, Hash, Debug)]
+#[derive(Clone, Debug)]
 pub struct Sequence {
     /// Optional anchor associated with this sequence.
     pub anchor: Option<String>,
     /// Elements of the YAML sequence.
     pub elements: Vec<Value>,
+    #[doc(hidden)]
+    pub id: usize,
+}
+
+impl Default for Sequence {
+    fn default() -> Self {
+        Sequence {
+            anchor: None,
+            elements: Vec::new(),
+            id: next_id(),
+        }
+    }
+}
+
+impl PartialEq for Sequence {
+    fn eq(&self, other: &Self) -> bool {
+        self.anchor == other.anchor && self.elements == other.elements
+    }
+}
+
+impl Eq for Sequence {}
+
+impl PartialOrd for Sequence {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match self.anchor.partial_cmp(&other.anchor) {
+            Some(std::cmp::Ordering::Equal) => self.elements.partial_cmp(&other.elements),
+            non_eq => non_eq,
+        }
+    }
+}
+
+impl std::hash::Hash for Sequence {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.anchor.hash(state);
+        self.elements.hash(state);
+    }
 }
 
 impl serde::Serialize for Sequence {
@@ -104,7 +147,7 @@ impl<'de> serde::Deserialize<'de> for Sequence {
         D: serde::Deserializer<'de>,
     {
         let elements = Vec::<Value>::deserialize(deserializer)?;
-        Ok(Sequence { anchor: None, elements })
+        Ok(Sequence { anchor: None, elements, id: next_id() })
     }
 }
 
@@ -148,10 +191,11 @@ impl std::ops::DerefMut for Sequence {
 impl Sequence {
     /// Creates an empty YAML sequence.
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Sequence {
             anchor: None,
             elements: Vec::new(),
+            id: next_id(),
         }
     }
 
@@ -161,6 +205,16 @@ impl Sequence {
         Sequence {
             anchor: None,
             elements: Vec::with_capacity(capacity),
+            id: next_id(),
+        }
+    }
+
+    /// Const constructor used for statics.
+    pub const fn const_new() -> Self {
+        Sequence {
+            anchor: None,
+            elements: Vec::new(),
+            id: 0,
         }
     }
 }
@@ -207,6 +261,14 @@ where
 }
 
 impl Value {
+    pub(crate) fn id(&self) -> usize {
+        match self {
+            Value::Sequence(seq) => seq.id,
+            Value::Mapping(map) => map.id,
+            Value::Tagged(tagged) => tagged.value.id(),
+            _ => self as *const _ as usize,
+        }
+    }
     /// Index into a YAML sequence or map. A string index can be used to access
     /// a value in a map, and a usize index can be used to access an element of
     /// an sequence.
@@ -561,13 +623,12 @@ impl Value {
     /// ```
     /// # use serde_yaml_bw::{Value, Number, Sequence};
     /// let v: Value = serde_yaml_bw::from_str("[1, 2]").unwrap();
-    /// let expected = Sequence {
-    ///     anchor: None,
-    ///     elements: vec![
-    ///         Value::Number(Number::from(1), None),
-    ///         Value::Number(Number::from(2), None),
-    ///     ],
-    /// };
+    /// let mut expected = Sequence::new();
+    /// expected.elements = vec![
+    ///     Value::Number(Number::from(1), None),
+    ///     Value::Number(Number::from(2), None),
+    /// ];
+    /// let expected = expected;
     /// assert_eq!(v.as_sequence(), Some(&expected));
     /// ```
     ///
@@ -591,13 +652,12 @@ impl Value {
     /// let mut v: Value = serde_yaml_bw::from_str("[1]").unwrap();
     /// let s = v.as_sequence_mut().unwrap();
     /// s.push(Value::Number(Number::from(2), None));
-    /// let expected = Sequence {
-    ///     anchor: None,
-    ///     elements: vec![
-    ///         Value::Number(Number::from(1), None),
-    ///         Value::Number(Number::from(2), None),
-    ///     ],
-    /// };
+    /// let mut expected = Sequence::new();
+    /// expected.elements = vec![
+    ///     Value::Number(Number::from(1), None),
+    ///     Value::Number(Number::from(2), None),
+    /// ];
+    /// let expected = expected;
     /// assert_eq!(s, &expected);
     /// ```
     ///
@@ -715,12 +775,12 @@ impl Value {
         let mut visited = HashSet::new();
         stack.push(self);
         while let Some(node) = stack.pop() {
-            let ptr = std::ptr::from_ref::<Value>(node) as usize;
-            if !visited.insert(ptr) {
-                return Err(error::new(ErrorImpl::MergeRecursion));
-            }
             match node {
                 Value::Mapping(mapping) => {
+                    let id = mapping.id;
+                    if id != 0 && !visited.insert(id) {
+                        return Err(error::new(ErrorImpl::MergeRecursion));
+                    }
                     match mapping.remove("<<") {
                         Some(Value::Mapping(merge)) => {
                             for (k, v) in merge {

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -141,7 +141,7 @@ impl ser::Serializer for Serializer {
             .iter()
             .map(|&b| Value::Number(Number::from(b), None))
             .collect();
-        Ok(Value::Sequence(Sequence { anchor: None, elements: vec }))
+        Ok(Value::Sequence(Sequence { anchor: None, elements: vec, id: crate::value::next_id() }))
     }
 
     fn serialize_unit(self) -> Result<Value> {

--- a/tests/test_merge_cycle.rs
+++ b/tests/test_merge_cycle.rs
@@ -7,6 +7,20 @@ fn test_self_referential_merge() {
     let mut value: Value = from_str_value_preserve(yaml).unwrap();
     assert!(value.apply_merge().is_err());
 }
+
+#[test]
+fn test_self_referential_after_reallocation() {
+    let yaml = "a: &a\n  b: 1\n  <<: *a";
+    let mut value: Value = from_str_value_preserve(yaml).unwrap();
+    let mut vec = Vec::new();
+    vec.push(Value::Null(None));
+    vec.push(value);
+    for _ in 0..100 {
+        vec.push(Value::Null(None));
+    }
+    let mut moved = vec.remove(1);
+    assert!(moved.apply_merge().is_err());
+}
 #[test]
 fn test_self_referential_merge_serde() {
     #[derive(Debug, Serialize, Deserialize)]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -509,17 +509,18 @@ fn test_value() {
     }
     let thing = GenericInstructions {
         typ: "primary".to_string(),
-        config: Value::Sequence(Sequence {
-            anchor: None,
-            elements: vec![
+        config: {
+            let mut seq = Sequence::new();
+            seq.elements = vec![
                 Value::Null(None),
                 Value::Bool(true, None),
                 Value::Number(Number::from(65535), None),
                 Value::Number(Number::from(0.54321), None),
                 Value::String("s".into(), None),
                 Value::Mapping(Mapping::new()),
-            ],
-        }),
+            ];
+            Value::Sequence(seq)
+        },
     };
     let yaml = indoc! {"
         type: primary


### PR DESCRIPTION
## Summary
- generate a unique id for every `Sequence` and `Mapping`
- track visited mappings by id when applying merges
- ignore temporary static sequences with id 0
- extend merge cycle tests to ensure detection after reallocation

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68702d01b8f0832c8dcf9d37f6daafef