### PR TITLE
Handle empty tags with error

### DIFF
--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -182,7 +182,7 @@ impl ser::Serializer for Serializer {
             return Err(error::new(ErrorImpl::EmptyTag));
         }
         Ok(Value::Tagged(Box::new(TaggedValue {
-            tag: Tag::new(variant),
+            tag: Tag::new(variant)?,
             value: to_value(value)?,
         })))
     }
@@ -336,7 +336,7 @@ impl ser::SerializeTupleVariant for SerializeTupleVariant {
 
     fn end(self) -> Result<Value> {
         Ok(Value::Tagged(Box::new(TaggedValue {
-            tag: Tag::new(self.tag),
+            tag: Tag::new(self.tag)?,
             value: Value::Sequence(self.sequence),
         })))
     }
@@ -758,7 +758,7 @@ impl ser::SerializeMap for SerializeMap {
                 *self = match key {
                     MaybeTag::Error => return Err(error::new(ErrorImpl::TagError)),
                     MaybeTag::Tag(string) => SerializeMap::Tagged(TaggedValue {
-                        tag: Tag::new(string),
+                        tag: Tag::new(string)?,
                         value: to_value(value)?,
                     }),
                     MaybeTag::NotTag(key) => {
@@ -838,7 +838,7 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
 
     fn end(self) -> Result<Value> {
         Ok(Value::Tagged(Box::new(TaggedValue {
-            tag: Tag::new(self.tag),
+            tag: Tag::new(self.tag)?,
             value: Value::Mapping(self.mapping),
         })))
     }

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -201,9 +201,9 @@ fn test_serialize_nested_enum() {
     assert_eq!(error.to_string(), expected);
 
     let e = Value::Tagged(Box::new(TaggedValue {
-        tag: Tag::new("Outer"),
+        tag: Tag::new("Outer").unwrap(),
         value: Value::Tagged(Box::new(TaggedValue {
-            tag: Tag::new("Inner"),
+            tag: Tag::new("Inner").unwrap(),
             value: Value::Null(None),
         })),
     }));

--- a/tests/test_tag.rs
+++ b/tests/test_tag.rs
@@ -1,0 +1,7 @@
+use serde_yaml_bw::value::Tag;
+
+#[test]
+fn tag_new_empty_returns_err() {
+    let err = Tag::new("").unwrap_err();
+    assert_eq!(err.to_string(), "empty YAML tag is not allowed");
+}


### PR DESCRIPTION
## Summary
- make `Tag::new` return a `Result` instead of panicking
- convert callers to handle the returned `Result`
- update documentation and tests for the new API
- add a test ensuring empty tags return an error

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68702c1bb034832c8b08e8a92a22c242