### PR TITLE
Handle missing writer in emitter

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -80,11 +80,15 @@ where
         Ok(())
     }
 
-    /// Unwrap the underlying `io::Write` object from the `Serializer`.
+    /// Return the underlying `io::Write` object from the `Serializer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the writer has already been taken.
     pub fn into_inner(mut self) -> Result<W> {
         self.emitter.emit(Event::StreamEnd)?;
         self.emitter.flush()?;
-        let writer = self.emitter.into_inner();
+        let writer = self.emitter.into_inner()?;
         Ok(writer)
     }
 


### PR DESCRIPTION
## Summary
- check for missing writer when taking the emitter's writer
- propagate the error in `Serializer::into_inner`
- note the new error in the method docs

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68702c278cb0832c93261f8646b499ca