### PR TITLE
Limit C string scanning

### DIFF
--- a/src/libyaml/parser.rs
+++ b/src/libyaml/parser.rs
@@ -1,5 +1,6 @@
-use crate::libyaml::cstr::{self, CStr};
-use crate::libyaml::error::{Error, Mark, Result};
+use crate::libyaml::cstr::{self, CStr, CStrError};
+use crate::libyaml::error::{Error as LibyamlError, Mark};
+use crate::error::{self, Error, ErrorImpl, Result};
 use crate::libyaml::tag::Tag;
 use crate::libyaml::util::Owned;
 use std::borrow::Cow;
@@ -72,7 +73,7 @@ impl<'input> Parser<'input> {
         let pin = unsafe {
             let parser = addr_of_mut!((*owned.ptr).sys);
             if sys::yaml_parser_initialize(parser).fail {
-                return Err(Error::parse_error(parser));
+                return Err(Error::from(LibyamlError::parse_error(parser)));
             }
             sys::yaml_parser_set_encoding(parser, sys::YAML_UTF8_ENCODING);
             sys::yaml_parser_set_input_string(parser, input.as_ptr(), input.len() as u64);
@@ -87,13 +88,14 @@ impl<'input> Parser<'input> {
         unsafe {
             let parser = addr_of_mut!((*self.pin.ptr).sys);
             if (&*parser).error != sys::YAML_NO_ERROR {
-                return Err(Error::parse_error(parser));
+                return Err(Error::from(LibyamlError::parse_error(parser)));
             }
             let event = event.as_mut_ptr();
             if sys::yaml_parser_parse(parser, event).fail {
-                return Err(Error::parse_error(parser));
+                return Err(Error::from(LibyamlError::parse_error(parser)));
             }
-            let ret = convert_event(&*event, &(*self.pin.ptr).input);
+            let ret = convert_event(&*event, &(*self.pin.ptr).input)
+                .map_err(|_| error::new(ErrorImpl::TagError))?;
             let mark = Mark {
                 sys: (*event).start_mark,
             };
@@ -106,19 +108,22 @@ impl<'input> Parser<'input> {
 unsafe fn convert_event<'input>(
     sys: &sys::yaml_event_t,
     input: &Cow<'input, [u8]>,
-) -> Event<'input> {
+) -> std::result::Result<Event<'input>, CStrError> {
     match sys.type_ {
-        sys::YAML_STREAM_START_EVENT => Event::StreamStart,
-        sys::YAML_STREAM_END_EVENT => Event::StreamEnd,
-        sys::YAML_DOCUMENT_START_EVENT => Event::DocumentStart,
-        sys::YAML_DOCUMENT_END_EVENT => Event::DocumentEnd,
+        sys::YAML_STREAM_START_EVENT => Ok(Event::StreamStart),
+        sys::YAML_STREAM_END_EVENT => Ok(Event::StreamEnd),
+        sys::YAML_DOCUMENT_START_EVENT => Ok(Event::DocumentStart),
+        sys::YAML_DOCUMENT_END_EVENT => Ok(Event::DocumentEnd),
         sys::YAML_ALIAS_EVENT => {
             // If we are unable to obtain anchor, if is still alias event.
-            Event::Alias(unsafe { optional_anchor(sys.data.alias.anchor) }.unwrap_or_else(|| Anchor("invalid_anchor".as_bytes().into())))
+            Ok(Event::Alias(
+                unsafe { optional_anchor(sys.data.alias.anchor) }?
+                    .unwrap_or_else(|| Anchor("invalid_anchor".as_bytes().into())),
+            ))
         }
-        sys::YAML_SCALAR_EVENT => Event::Scalar(Scalar {
-            anchor: unsafe { optional_anchor(sys.data.scalar.anchor) },
-            tag: unsafe { optional_tag(sys.data.scalar.tag) },
+        sys::YAML_SCALAR_EVENT => Ok(Event::Scalar(Scalar {
+            anchor: unsafe { optional_anchor(sys.data.scalar.anchor) }?,
+            tag: unsafe { optional_tag(sys.data.scalar.tag) }?,
             value: Box::from(unsafe {
                 slice::from_raw_parts(sys.data.scalar.value, sys.data.scalar.length as usize)
             }),
@@ -136,33 +141,39 @@ unsafe fn convert_event<'input>(
             } else {
                 None
             },
-        }),
-        sys::YAML_SEQUENCE_START_EVENT => Event::SequenceStart(SequenceStart {
-            anchor: unsafe { optional_anchor(sys.data.sequence_start.anchor) },
-            tag: unsafe { optional_tag(sys.data.sequence_start.tag) },
-        }),
-        sys::YAML_SEQUENCE_END_EVENT => Event::SequenceEnd,
-        sys::YAML_MAPPING_START_EVENT => Event::MappingStart(MappingStart {
-            anchor: unsafe { optional_anchor(sys.data.mapping_start.anchor) },
-            tag: unsafe { optional_tag(sys.data.mapping_start.tag) },
-        }),
-        sys::YAML_MAPPING_END_EVENT => Event::MappingEnd,
+        })),
+        sys::YAML_SEQUENCE_START_EVENT => Ok(Event::SequenceStart(SequenceStart {
+            anchor: unsafe { optional_anchor(sys.data.sequence_start.anchor) }?,
+            tag: unsafe { optional_tag(sys.data.sequence_start.tag) }?,
+        })),
+        sys::YAML_SEQUENCE_END_EVENT => Ok(Event::SequenceEnd),
+        sys::YAML_MAPPING_START_EVENT => Ok(Event::MappingStart(MappingStart {
+            anchor: unsafe { optional_anchor(sys.data.mapping_start.anchor) }?,
+            tag: unsafe { optional_tag(sys.data.mapping_start.tag) }?,
+        })),
+        sys::YAML_MAPPING_END_EVENT => Ok(Event::MappingEnd),
         // Unknown or empty events should not cause a panic
-        sys::YAML_NO_EVENT => Event::Void,
-        _ => Event::Void,
+        sys::YAML_NO_EVENT => Ok(Event::Void),
+        _ => Ok(Event::Void),
     }
 }
 
-unsafe fn optional_anchor(anchor: *const u8) -> Option<Anchor> {
-    let ptr = NonNull::new(anchor as *mut i8)?;
+unsafe fn optional_anchor(anchor: *const u8) -> std::result::Result<Option<Anchor>, CStrError> {
+    let ptr = match NonNull::new(anchor as *mut i8) {
+        Some(p) => p,
+        None => return Ok(None),
+    };
     let cstr = unsafe { CStr::from_ptr(ptr) };
-    Some(Anchor(Box::from(cstr.to_bytes())))
+    Ok(Some(Anchor(Box::from(cstr.to_bytes()?))))
 }
 
-unsafe fn optional_tag(tag: *const u8) -> Option<Tag> {
-    let ptr = NonNull::new(tag as *mut i8)?;
+unsafe fn optional_tag(tag: *const u8) -> std::result::Result<Option<Tag>, CStrError> {
+    let ptr = match NonNull::new(tag as *mut i8) {
+        Some(p) => p,
+        None => return Ok(None),
+    };
     let cstr = unsafe { CStr::from_ptr(ptr) };
-    Some(Tag(Box::from(cstr.to_bytes())))
+    Ok(Some(Tag(Box::from(cstr.to_bytes()?))))
 }
 
 impl Debug for Scalar<'_> {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,5 +1,5 @@
 use crate::de::{Event, Progress, ScalarEvent, SequenceStartEvent, MappingStartEvent};
-use crate::error::{self, Error, ErrorImpl, Result};
+use crate::error::{self, ErrorImpl, Result};
 use crate::libyaml::error::Mark;
 use crate::libyaml::parser::{Event as YamlEvent, Parser, Anchor};
 use std::borrow::Cow;
@@ -76,7 +76,7 @@ impl<'input> Loader<'input> {
                         self.parser = None;
                         return None;
                     }
-                    document.error = Some(Error::from(err).shared());
+                    document.error = Some(err.shared());
                     return Some(document);
                 }
             };

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -260,6 +260,16 @@ fn test_variant_not_a_seq() {
 }
 
 #[test]
+fn test_anchor_too_long() {
+    use serde_yaml_bw::Value;
+    const MAX: usize = 65_536;
+    let long = "a".repeat(MAX + 1);
+    let yaml = format!("&{long} 1\n");
+    let expected = "unexpected tag error";
+    test_error::<Value>(&yaml, expected);
+}
+
+#[test]
 fn test_struct_from_sequence() {
     #[derive(Deserialize, Debug)]
     pub struct Struct {


### PR DESCRIPTION
## Summary
- add `MAX_NAME_LENGTH` and document the limit on anchor and tag names
- return error from C string parsing when the limit is exceeded
- surface the new error through the parser as `ErrorImpl::TagError`
- test normal and overlong C strings and anchors

## Testing
- `cargo check`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68702d706084832cba66be4129944d3e