### PR TITLE
Clarify memory check logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Since the API has changed to a more restrictive version, the major version numbe
 
 If a panic does occur under some short and clear input, please report it as a bug.
 
+### Memory usage
+
+`from_reader` and `from_slice` first load the entire YAML stream into memory.
+For very large or malicious inputs this may exhaust available memory.  As of
+[issue #3](https://github.com/bourumir-wyngs/serde-yaml-bw/issues/3), these
+functions optionally accept a size limit that aborts parsing once exceeded.
+The loader also checks that the input fits into available RAM while keeping a
+25% safety margin. On non-Linux platforms this check may be unavailable so
+the explicit size limit provides a portable safeguard.
+Use the limit when processing untrusted documents.
+
 ### Thread Safety
 
 Internally the library uses a `CStr` wrapper for libyaml strings. This type is


### PR DESCRIPTION
## Summary
- document that memory check may be unavailable on non-Linux systems
- clarify safety margin function in loader

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68702da30668832ca0c38fc59c76e174