### PR TITLE
Remove unused Sequence id

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -728,7 +728,7 @@ impl<'de, 'document> DeserializerFromEvents<'de, 'document> {
                     elements.push(self.parse_value()?);
                 }
                 self.next_event()?; // consume SequenceEnd
-                Ok(Value::Sequence(Sequence { anchor, elements, id: crate::value::next_id() }))
+                Ok(Value::Sequence(Sequence { anchor, elements }))
             }
             MappingStart(map) => {
                 let anchor = map.anchor.clone();

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -128,7 +128,6 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
         Value::Sequence(Sequence {
             anchor: None,
             elements: f.into_iter().map(Into::into).collect(),
-            id: crate::value::next_id(),
         })
     }
 }
@@ -148,7 +147,6 @@ impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
         Value::Sequence(Sequence {
             anchor: None,
             elements: f.iter().cloned().map(Into::into).collect(),
-            id: crate::value::next_id(),
         })
     }
 }
@@ -184,7 +182,6 @@ impl<T: Into<Value>> FromIterator<T> for Value {
         Value::Sequence(Sequence {
             anchor: None,
             elements: vec,
-            id: crate::value::next_id(),
         })
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -94,8 +94,6 @@ pub struct Sequence {
     pub anchor: Option<String>,
     /// Elements of the YAML sequence.
     pub elements: Vec<Value>,
-    #[doc(hidden)]
-    pub(crate) id: usize,
 }
 
 impl Default for Sequence {
@@ -103,7 +101,6 @@ impl Default for Sequence {
         Sequence {
             anchor: None,
             elements: Vec::new(),
-            id: next_id(),
         }
     }
 }
@@ -147,7 +144,7 @@ impl<'de> serde::Deserialize<'de> for Sequence {
         D: serde::Deserializer<'de>,
     {
         let elements = Vec::<Value>::deserialize(deserializer)?;
-        Ok(Sequence { anchor: None, elements, id: next_id() })
+        Ok(Sequence { anchor: None, elements })
     }
 }
 
@@ -195,7 +192,6 @@ impl Sequence {
         Sequence {
             anchor: None,
             elements: Vec::new(),
-            id: next_id(),
         }
     }
 
@@ -205,7 +201,6 @@ impl Sequence {
         Sequence {
             anchor: None,
             elements: Vec::with_capacity(capacity),
-            id: next_id(),
         }
     }
 
@@ -214,7 +209,6 @@ impl Sequence {
         Sequence {
             anchor: None,
             elements: Vec::new(),
-            id: 0,
         }
     }
 }
@@ -261,14 +255,6 @@ where
 }
 
 impl Value {
-    pub(crate) fn id(&self) -> usize {
-        match self {
-            Value::Sequence(seq) => seq.id,
-            Value::Mapping(map) => map.id,
-            Value::Tagged(tagged) => tagged.value.id(),
-            _ => self as *const _ as usize,
-        }
-    }
     /// Index into a YAML sequence or map. A string index can be used to access
     /// a value in a map, and a usize index can be used to access an element of
     /// an sequence.

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -141,7 +141,7 @@ impl ser::Serializer for Serializer {
             .iter()
             .map(|&b| Value::Number(Number::from(b), None))
             .collect();
-        Ok(Value::Sequence(Sequence { anchor: None, elements: vec, id: crate::value::next_id() }))
+        Ok(Value::Sequence(Sequence { anchor: None, elements: vec }))
     }
 
     fn serialize_unit(self) -> Result<Value> {


### PR DESCRIPTION
## Summary
- drop the unused `id` from `Sequence`
- eliminate associated initializations in constructors and conversions
- adjust deserialization and serialization to build sequences without an id
- remove the `Value::id` helper since it was only used for the removed field

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68718238ce5c832c8c159033727a127e