### PR TITLE
Improve alias handling efficiency

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -507,7 +507,7 @@ impl<'de, 'document> DeserializerFromEvents<'de, 'document> {
         if *self.jumpcount > limit {
             return Err(error::new(ErrorImpl::RepetitionLimitExceeded));
         }
-        match self.document.aliases.get(pos) {
+        match self.document.aliases.get(*pos) {
             Some(found) => {
                 *pos = *found;
                 Ok(DeserializerFromEvents {
@@ -706,7 +706,7 @@ impl<'de, 'document> DeserializerFromEvents<'de, 'document> {
         use Event::{Alias, MappingEnd, MappingStart, Scalar, SequenceEnd, SequenceStart, Void};
         let (event, _mark) = self.next_event_mark()?;
         match event {
-            Alias(id) => {
+            &Alias(id) => {
                 let alias_index = match self.document.aliases.get(id) {
                     Some(idx) => *idx,
                     None => return Err(error::new(ErrorImpl::UnresolvedAlias)),

--- a/src/libyaml/parser.rs
+++ b/src/libyaml/parser.rs
@@ -57,7 +57,7 @@ pub(crate) struct MappingStart {
     pub tag: Option<Tag>,
 }
 
-#[derive(Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub(crate) struct Anchor(pub(crate) Box<[u8]>);
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -3,7 +3,7 @@ use crate::error::{self, ErrorImpl, Result};
 use crate::libyaml::error::Mark;
 use crate::libyaml::parser::{Anchor, Event as YamlEvent, Parser};
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 fn anchor_to_string(anchor: &Anchor) -> String {
@@ -19,7 +19,7 @@ pub(crate) struct Document<'input> {
     pub events: Vec<(Event<'input>, Mark)>,
     pub error: Option<Arc<ErrorImpl>>,
     /// Map from alias id to index in events.
-    pub aliases: BTreeMap<usize, usize>,
+    pub aliases: Vec<usize>,
     /// Location of the explicit document end marker if present.
     pub end_mark: Option<Mark>,
 }
@@ -50,11 +50,11 @@ impl<'input> Loader<'input> {
         let first = self.document_count == 0;
         self.document_count += 1;
 
-        let mut anchors = BTreeMap::new();
+        let mut anchors = HashMap::new();
         let mut document = Document {
             events: Vec::new(),
             error: None,
-            aliases: BTreeMap::new(),
+            aliases: Vec::new(),
             end_mark: None,
         };
 
@@ -105,7 +105,7 @@ impl<'input> Loader<'input> {
                         let name = anchor_to_string(&a);
                         let id = anchors.len();
                         anchors.insert(a, id);
-                        document.aliases.insert(id, document.events.len());
+                        document.aliases.push(document.events.len());
                         name
                     });
                     Event::Scalar(ScalarEvent {
@@ -118,7 +118,7 @@ impl<'input> Loader<'input> {
                         let name = anchor_to_string(&a);
                         let id = anchors.len();
                         anchors.insert(a, id);
-                        document.aliases.insert(id, document.events.len());
+                        document.aliases.push(document.events.len());
                         name
                     });
                     Event::SequenceStart(SequenceStartEvent {
@@ -132,7 +132,7 @@ impl<'input> Loader<'input> {
                         let name = anchor_to_string(&a);
                         let id = anchors.len();
                         anchors.insert(a, id);
-                        document.aliases.insert(id, document.events.len());
+                        document.aliases.push(document.events.len());
                         name
                     });
                     Event::MappingStart(MappingStartEvent {


### PR DESCRIPTION
## Summary
- store aliases in a `Vec` instead of a `BTreeMap`
- switch loader anchor lookup to `HashMap`
- derive `Hash` for `Anchor`
- adjust deserializer to work with the new alias structure

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6872a82791b0832c975ceabd330292cf