### PR TITLE
Add unit tests for missing functionality

### DIFF
--- a/src/duplicate_key.rs
+++ b/src/duplicate_key.rs
@@ -73,3 +73,41 @@ impl Display for DuplicateKeyError {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{parse_bool, is_null, DuplicateKeyError, DuplicateKeyKind};
+    use crate::number::Number;
+
+    #[test]
+    fn test_is_null_variants() {
+        assert!(is_null(b"null"));
+        assert!(is_null(b"Null"));
+        assert!(is_null(b"NULL"));
+        assert!(is_null(b"~"));
+        assert!(!is_null(b"nul"));
+    }
+
+    #[test]
+    fn test_parse_bool_variants() {
+        assert_eq!(parse_bool("true"), Some(true));
+        assert_eq!(parse_bool("True"), Some(true));
+        assert_eq!(parse_bool("TRUE"), Some(true));
+        assert_eq!(parse_bool("false"), Some(false));
+        assert_eq!(parse_bool("False"), Some(false));
+        assert_eq!(parse_bool("FALSE"), Some(false));
+        assert_eq!(parse_bool("other"), None);
+    }
+
+    #[test]
+    fn test_from_scalar_parsing() {
+        let err = DuplicateKeyError::from_scalar(b"null");
+        matches!(err.kind, DuplicateKeyKind::Null);
+
+        let err = DuplicateKeyError::from_scalar(b"true");
+        matches!(err.kind, DuplicateKeyKind::Bool(true));
+
+        let err = DuplicateKeyError::from_scalar(b"42");
+        assert!(matches!(err.kind, DuplicateKeyKind::Number(n) if n == Number::from(42)));
+    }
+}
+

--- a/src/path.rs
+++ b/src/path.rs
@@ -32,3 +32,26 @@ impl Display for Path<'_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Path;
+
+    #[test]
+    fn test_display_variants() {
+        let root = Path::Root;
+        assert_eq!(format!("{}", root), ".");
+
+        let seq = Path::Seq { parent: &root, index: 1 };
+        assert_eq!(format!("{}", seq), ".[1]");
+
+        let map = Path::Map { parent: &seq, key: "name" };
+        assert_eq!(format!("{}", map), ".[1].name");
+
+        let alias = Path::Alias { parent: &map };
+        assert_eq!(format!("{}", alias), ".[1].name");
+
+        let unknown = Path::Unknown { parent: &map };
+        assert_eq!(format!("{}", unknown), ".[1].name.?");
+    }
+}

--- a/tests/test_mapping_ops.rs
+++ b/tests/test_mapping_ops.rs
@@ -1,0 +1,52 @@
+use serde_yaml_bw::{Mapping, Value};
+
+#[test]
+fn test_reserve_and_shrink() {
+    let mut map = Mapping::new();
+    let initial = map.capacity();
+    map.reserve(10);
+    assert!(map.capacity() >= initial + 10);
+
+    map.insert("a".into(), 1.into());
+    map.insert("b".into(), 2.into());
+    let cap_before = map.capacity();
+    map.shrink_to_fit();
+    assert!(map.capacity() <= cap_before);
+    assert!(map.capacity() >= map.len());
+}
+
+#[test]
+fn test_swap_and_shift_remove() {
+    let mut map = Mapping::new();
+    map.insert("a".into(), 1.into());
+    map.insert("b".into(), 2.into());
+    map.insert("c".into(), 3.into());
+
+    let removed = map.swap_remove("b");
+    assert_eq!(removed, Some(Value::from(2)));
+    assert!(!map.contains_key("b"));
+    assert_eq!(map.len(), 2);
+
+    let mut map2 = Mapping::new();
+    map2.insert("a".into(), 1.into());
+    map2.insert("b".into(), 2.into());
+    map2.insert("c".into(), 3.into());
+
+    let removed = map2.shift_remove("b");
+    assert_eq!(removed, Some(Value::from(2)));
+    assert!(!map2.contains_key("b"));
+    let keys: Vec<_> = map2.keys().map(|k| k.as_str().unwrap().to_string()).collect();
+    assert_eq!(keys, ["a", "c"]);
+}
+
+#[test]
+fn test_iterators() {
+    let mut map = Mapping::new();
+    map.insert("x".into(), 1.into());
+    map.insert("y".into(), 2.into());
+
+    let keys: Vec<_> = map.keys().map(|k| k.as_str().unwrap().to_string()).collect();
+    assert_eq!(keys, ["x", "y"]);
+    let values: Vec<_> = map.values().map(|v| v.as_i64().unwrap()).collect();
+    assert_eq!(values, [1, 2]);
+}

--- a/tests/test_number_methods.rs
+++ b/tests/test_number_methods.rs
@@ -1,0 +1,27 @@
+use serde_yaml_bw::Number;
+
+#[test]
+fn test_is_i64_and_as_i64() {
+    let neg = Number::from(-5i64);
+    assert!(neg.is_i64());
+    assert_eq!(neg.as_i64(), Some(-5));
+
+    let pos = Number::from(5u64);
+    assert!(pos.is_i64());
+    assert_eq!(pos.as_i64(), Some(5));
+
+    let big = Number::from(u64::MAX);
+    assert!(!big.is_i64());
+    assert_eq!(big.as_i64(), None);
+}
+
+#[test]
+fn test_is_infinite_and_finite() {
+    let inf = Number::from(f64::INFINITY);
+    assert!(inf.is_infinite());
+    assert!(!inf.is_finite());
+
+    let finite = Number::from(10);
+    assert!(!finite.is_infinite());
+    assert!(finite.is_finite());
+}


### PR DESCRIPTION
## Summary
- add tests for duplicate-key helpers
- cover Mapping capacity helpers, removal methods, and iterators
- test Number accessors
- verify Path display formatting

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6872a8010e24832cadc6d197473e2b8a