### PR TITLE
Add tag stack to Serializer

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -47,6 +47,8 @@ where
 {
     depth: usize,
     state: State,
+    /// Stack of YAML tags currently in scope.
+    tag_stack: Vec<String>,
     emitter: Emitter<W>,
 }
 
@@ -69,6 +71,7 @@ where
         Ok(Serializer {
             depth: 0,
             state: State::NothingInParticular,
+            tag_stack: Vec::new(),
             emitter,
         })
     }


### PR DESCRIPTION
## Summary
- store a stack of YAML tags in `Serializer`
- initialize the stack in `Serializer::new`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68737e569efc832ca1250ca96cbe5a83