### PR TITLE
Remove SerializeNestedEnum error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,6 @@ pub(crate) enum ErrorImpl {
     RepetitionLimitExceeded,
     BytesUnsupported,
     UnknownAnchor(libyaml::Mark, Anchor),
-    SerializeNestedEnum,
     ScalarInMerge,
     TaggedInMerge,
     ScalarInMergeElement,
@@ -251,9 +250,6 @@ impl ErrorImpl {
             }
             ErrorImpl::UnknownAnchor(_mark, alias) => f.write_str(
                 &format!("unknown anchor [{}]", &sanitize(alias))),
-            ErrorImpl::SerializeNestedEnum => {
-                f.write_str("serializing nested enums in YAML is not supported yet")
-            }
             ErrorImpl::ScalarInMerge => {
                 f.write_str("expected a mapping or list of mappings for merging, but found scalar")
             }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -517,12 +517,8 @@ where
                 MaybeTag::Error => return Err(error::new(ErrorImpl::TagError)),
                 MaybeTag::NotTag(string) => string,
                 MaybeTag::Tag(string) => {
-                    return if !self.tag_stack.is_empty() || matches!(self.state, State::CheckForDuplicateTag) {
-                        Err(error::new(ErrorImpl::SerializeNestedEnum))
-                    } else {
-                        self.state = State::FoundTag(string);
-                        Ok(())
-                    };
+                    self.state = State::FoundTag(string);
+                    return Ok(());
                 }
             }
         } else {

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -5,7 +5,7 @@ use serde::de::Deserialize;
 #[cfg(not(miri))]
 use serde::de::{SeqAccess, Visitor};
 use serde_derive::{Deserialize, Serialize};
-use serde_yaml_bw::value::{Tag, TaggedValue};
+
 use serde_yaml_bw::{Deserializer, Value};
 #[cfg(not(miri))]
 use std::collections::BTreeMap;
@@ -208,17 +208,6 @@ fn test_serialize_nested_enum() {
     let yaml = serde_yaml_bw::to_string(&Outer::Inner(Inner::Struct { x: 0 })).unwrap();
     assert_eq!(yaml, "!Struct\nx: 0\n");
 
-    let expected = "serializing nested enums in YAML is not supported yet";
-
-    let e = Value::Tagged(Box::new(TaggedValue {
-        tag: Tag::new("Outer").unwrap(),
-        value: Value::Tagged(Box::new(TaggedValue {
-            tag: Tag::new("Inner").unwrap(),
-            value: Value::Null(None),
-        })),
-    }));
-    let error = serde_yaml_bw::to_string(&e).unwrap_err();
-    assert_eq!(error.to_string(), expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove `SerializeNestedEnum` variant from `ErrorImpl`
- drop error handling for nested enum serialization
- update related tests

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68738a3d1e24832cb56d3dd99869c8b0