### PR TITLE
Support nested enums via tag stack

### DIFF
--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -202,16 +202,16 @@ fn test_serialize_nested_enum() {
     let expected = "serializing nested enums in YAML is not supported yet";
 
     let e = Outer::Inner(Inner::Newtype(0));
-    let error = serde_yaml_bw::to_string(&e).unwrap_err();
-    assert_eq!(error.to_string(), expected);
+    let yaml = "!Newtype 0\n";
+    assert_eq!(serde_yaml_bw::to_string(&e).unwrap(), yaml);
 
     let e = Outer::Inner(Inner::Tuple(0, 0));
-    let error = serde_yaml_bw::to_string(&e).unwrap_err();
-    assert_eq!(error.to_string(), expected);
+    let yaml = indoc!("!Tuple\n- 0\n- 0\n");
+    assert_eq!(serde_yaml_bw::to_string(&e).unwrap(), yaml);
 
     let e = Outer::Inner(Inner::Struct { x: 0 });
-    let error = serde_yaml_bw::to_string(&e).unwrap_err();
-    assert_eq!(error.to_string(), expected);
+    let yaml = indoc!("!Struct\nx: 0\n");
+    assert_eq!(serde_yaml_bw::to_string(&e).unwrap(), yaml);
 
     let e = Value::Tagged(Box::new(TaggedValue {
         tag: Tag::new("Outer").unwrap(),


### PR DESCRIPTION
## Summary
- add internal tag stack helpers
- push active tag when starting nested enum variants
- restore tag stack on variant end
- detect nested enums in `collect_str`
- update nested enum test expectations

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687382c58a10832c8172736d1622614f