### PR TITLE
Add helpers for multi-document arrays

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -2021,6 +2021,49 @@ where
     crate::value::from_value(value)
 }
 
+/// Deserialize a list of `T` from multiple YAML documents provided in a string.
+pub fn from_str_multi<T>(s: &str) -> Result<Vec<T>>
+where
+    T: DeserializeOwned,
+{
+    Deserializer::from_str(s)
+        .map(|doc| {
+            let mut value: Value = Value::deserialize(doc)?;
+            value.apply_merge()?;
+            crate::value::from_value(value)
+        })
+        .collect()
+}
+
+/// Deserialize a list of `T` from multiple YAML documents provided in an IO stream.
+pub fn from_reader_multi<R, T>(rdr: R) -> Result<Vec<T>>
+where
+    R: io::Read,
+    T: DeserializeOwned,
+{
+    Deserializer::from_reader(rdr)
+        .map(|doc| {
+            let mut value: Value = Value::deserialize(doc)?;
+            value.apply_merge()?;
+            crate::value::from_value(value)
+        })
+        .collect()
+}
+
+/// Deserialize a list of `T` from multiple YAML documents provided in bytes.
+pub fn from_slice_multi<T>(v: &[u8]) -> Result<Vec<T>>
+where
+    T: DeserializeOwned,
+{
+    Deserializer::from_slice(v)
+        .map(|doc| {
+            let mut value: Value = Value::deserialize(doc)?;
+            value.apply_merge()?;
+            crate::value::from_value(value)
+        })
+        .collect()
+}
+
 /// Deserialize a YAML `Value` while preserving anchors and aliases.
 #[allow(clippy::redundant_closure_for_method_calls)]
 pub fn from_str_value_preserve(s: &str) -> Result<Value> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,9 +160,14 @@
     clippy::must_use_candidate,
 )]
 
-pub use crate::de::{from_reader, from_slice, from_str, from_str_value_preserve, Deserializer};
+pub use crate::de::{
+    from_reader, from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi,
+    from_str_value_preserve, Deserializer,
+};
 pub use crate::error::{Error, Location, Result};
-pub use crate::ser::{to_string, to_writer, Serializer};
+pub use crate::ser::{
+    to_string, to_string_multi, to_writer, to_writer_multi, Serializer,
+};
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Number, Sequence, Value};
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -726,3 +726,26 @@ where
     to_writer(&mut vec, value)?;
     String::from_utf8(vec).map_err(|error| error::new(ErrorImpl::FromUtf8(error)))
 }
+
+/// Serialize the given array of data structures as multiple YAML documents into the IO stream.
+pub fn to_writer_multi<W, T>(writer: W, values: &[T]) -> Result<()>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    let mut serializer = Serializer::new(writer)?;
+    for value in values {
+        value.serialize(&mut serializer)?;
+    }
+    Ok(())
+}
+
+/// Serialize the given array of data structures as a YAML multi-document string.
+pub fn to_string_multi<T>(values: &[T]) -> Result<String>
+where
+    T: ser::Serialize,
+{
+    let mut vec = Vec::with_capacity(128);
+    to_writer_multi(&mut vec, values)?;
+    String::from_utf8(vec).map_err(|error| error::new(ErrorImpl::FromUtf8(error)))
+}

--- a/tests/test_multi_helpers.rs
+++ b/tests/test_multi_helpers.rs
@@ -1,0 +1,21 @@
+use serde_derive::{Deserialize, Serialize};
+use indoc::indoc;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Point {
+    x: i32,
+}
+
+#[test]
+fn test_from_str_multi() {
+    let yaml = indoc!("---\nx: 1\n---\nx: 2\n");
+    let points: Vec<Point> = serde_yaml_bw::from_str_multi(yaml).unwrap();
+    assert_eq!(points, vec![Point { x: 1 }, Point { x: 2 }]);
+}
+
+#[test]
+fn test_to_string_multi() {
+    let points = vec![Point { x: 1 }, Point { x: 2 }];
+    let out = serde_yaml_bw::to_string_multi(&points).unwrap();
+    assert_eq!(out, "x: 1\n---\nx: 2\n");
+}


### PR DESCRIPTION
## Summary
- add `from_*_multi` helpers to deserialize arrays from multi-doc YAML
- add `to_*_multi` helpers to serialize arrays as multi-doc YAML
- re-export new helpers
- test new helpers

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68746c8d4068832c900475e4ea584a9a