### PR TITLE
Remove unused libyaml error reexport

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -860,7 +860,6 @@ impl<'de> de::MapAccess<'de> for MapAccess<'de, '_, '_> {
 
 struct EnumAccess<'de, 'document, 'variant> {
     de: &'variant mut DeserializerFromEvents<'de, 'document>,
-    name: Option<&'static str>,
     tag: &'document str,
 }
 
@@ -1386,7 +1385,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                         *self.pos -= 1;
                         break visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: None,
                             tag,
                         });
                     }
@@ -1397,7 +1395,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                         *self.pos -= 1;
                         break visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: None,
                             tag,
                         });
                     }
@@ -1408,7 +1405,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                         *self.pos -= 1;
                         break visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: None,
                             tag,
                         });
                     }
@@ -1898,7 +1894,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                 if let Some(tag) = parse_tag(scalar.value.tag.as_ref()) {
                     return visitor.visit_enum(EnumAccess {
                         de: self,
-                        name: Some(name),
                         tag,
                     });
                 }
@@ -1908,7 +1903,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                 if let Some(tag) = parse_tag(mapping.tag.as_ref()) {
                     return visitor.visit_enum(EnumAccess {
                         de: self,
-                        name: Some(name),
                         tag,
                     });
                 }
@@ -1943,7 +1937,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                 };
                 let result = visitor.visit_enum(EnumAccess {
                     de: self,
-                    name: Some(name),
                     tag,
                 });
                 let result = result.and_then(|v| {
@@ -1956,7 +1949,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                     if let Some(tag) = parse_tag(sequence.tag.as_ref()) {
                         return visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: Some(name),
                             tag,
                         });
                     }

--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -76,7 +76,7 @@ where
         let pin = unsafe {
             let emitter = addr_of_mut!((*owned.ptr).sys);
             if sys::yaml_emitter_initialize(emitter).fail {
-                return Err(Error::Libyaml(libyaml::Error::emit_error(emitter)));
+                return Err(Error::Libyaml(libyaml::error::Error::emit_error(emitter)));
             }
             sys::yaml_emitter_set_unicode(emitter, true);
             sys::yaml_emitter_set_width(emitter, -1);
@@ -170,7 +170,7 @@ where
                 Event::MappingEnd => sys::yaml_mapping_end_event_initialize(sys_event),
             };
             if initialize_status.fail {
-                return Err(Error::Libyaml(libyaml::Error::emit_error(emitter)));
+                return Err(Error::Libyaml(libyaml::error::Error::emit_error(emitter)));
             }
             if sys::yaml_emitter_emit(emitter, sys_event).fail {
                 return Err(self.error());
@@ -206,7 +206,7 @@ where
         if let Some(write_error) = emitter.write_error.take() {
             Error::Io(write_error)
         } else {
-            Error::Libyaml(unsafe { libyaml::Error::emit_error(&raw const emitter.sys) })
+            Error::Libyaml(unsafe { libyaml::error::Error::emit_error(&raw const emitter.sys) })
         }
     }
 }

--- a/src/libyaml/mod.rs
+++ b/src/libyaml/mod.rs
@@ -4,5 +4,3 @@ pub mod error;
 pub mod parser;
 pub mod tag;
 mod util;
-
-use self::error::Error;


### PR DESCRIPTION
## Summary
- drop redundant `use self::error::Error` reexport
- reference error type directly in libyaml emitter
- trim dead `name` field from `EnumAccess`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68747b30f1f8832cb4dbdd95fcf7ea25