### PR TITLE
Add IO helper and duplicate key tests

### DIFF
--- a/src/duplicate_key.rs
+++ b/src/duplicate_key.rs
@@ -109,5 +109,11 @@ mod tests {
         let err = DuplicateKeyError::from_scalar(b"42");
         assert!(matches!(err.kind, DuplicateKeyKind::Number(n) if n == Number::from(42)));
     }
+
+    #[test]
+    fn test_display() {
+        let err = DuplicateKeyError::from_scalar(b"dup");
+        assert_eq!(format!("{}", err), "duplicate entry with key \"dup\"");
+    }
 }
 

--- a/tests/test_io_helpers.rs
+++ b/tests/test_io_helpers.rs
@@ -1,0 +1,48 @@
+use serde_derive::{Deserialize, Serialize};
+use std::io::Cursor;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Point {
+    x: i32,
+}
+
+#[test]
+fn test_from_slice_and_multi() {
+    let bytes = b"x: 1\n";
+    let point: Point = serde_yaml_bw::from_slice(bytes).unwrap();
+    assert_eq!(point, Point { x: 1 });
+
+    let multi = b"---\nx: 1\n---\nx: 2\n";
+    let points: Vec<Point> = serde_yaml_bw::from_slice_multi(multi).unwrap();
+    assert_eq!(points, vec![Point { x: 1 }, Point { x: 2 }]);
+}
+
+#[test]
+fn test_from_reader_multi() {
+    let multi = b"---\nx: 1\n---\nx: 2\n".to_vec();
+    let cursor = Cursor::new(multi);
+    let points: Vec<Point> = serde_yaml_bw::from_reader_multi(cursor).unwrap();
+    assert_eq!(points, vec![Point { x: 1 }, Point { x: 2 }]);
+}
+
+#[test]
+fn test_to_writer_and_multi() {
+    let mut buf = Vec::new();
+    let point = Point { x: 1 };
+    serde_yaml_bw::to_writer(&mut buf, &point).unwrap();
+    assert_eq!(String::from_utf8(buf.clone()).unwrap(), "x: 1\n");
+
+    buf.clear();
+    let points = vec![Point { x: 1 }, Point { x: 2 }];
+    serde_yaml_bw::to_writer_multi(&mut buf, &points).unwrap();
+    assert_eq!(String::from_utf8(buf).unwrap(), "x: 1\n---\nx: 2\n");
+}
+
+#[test]
+fn test_error_location() {
+    let result: Result<Point, _> = serde_yaml_bw::from_str("@");
+    let err = result.unwrap_err();
+    let loc = err.location().expect("location missing");
+    assert_eq!(loc.line(), 1);
+    assert_eq!(loc.column(), 1);
+}


### PR DESCRIPTION
## Summary
- test IO helper functions for slice/reader/writer scenarios
- verify error location from `from_str`
- cover `DuplicateKeyError` display formatting

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68747b75440c832cac609e33c89be489