### PR TITLE
Add Tag display and equality tests

### DIFF
--- a/tests/test_tag_display.rs
+++ b/tests/test_tag_display.rs
@@ -1,0 +1,14 @@
+use serde_yaml_bw::value::Tag;
+
+#[test]
+fn tag_equality_ignores_leading_bang() {
+    let tag_plain = Tag::new("Thing").unwrap();
+    let tag_banged = Tag::new("!Thing").unwrap();
+    assert_eq!(tag_plain, tag_banged);
+}
+
+#[test]
+fn tag_display_includes_bang() {
+    let tag = Tag::new("Thing").unwrap();
+    assert_eq!(format!("{}", tag), "!Thing");
+}


### PR DESCRIPTION
## Summary
- add tests for `Tag` equality ignoring leading `!`
- check `Tag` display outputs the leading `!`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68747b9f1ea8832c826ddf3aa6896aed