### PR TITLE
Add Value indexing tests

### DIFF
--- a/tests/test_value_index.rs
+++ b/tests/test_value_index.rs
@@ -1,0 +1,8 @@
+use serde_yaml_bw::Value;
+
+#[test]
+fn test_value_index_returns_null() {
+    let value: Value = serde_yaml_bw::from_str("{a: {b: 1}}" ).unwrap();
+    assert_eq!(value["a"]["c"], Value::Null(None));
+    assert_eq!(value["x"][0], Value::Null(None));
+}


### PR DESCRIPTION
## Summary
- add new test verifying nested indexing returns `Value::Null(None)` for missing keys

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68747ba10950832c86bd243173ba010d