### PR TITLE
Add error formatting test

### DIFF
--- a/tests/test_error_format.rs
+++ b/tests/test_error_format.rs
@@ -1,0 +1,19 @@
+use serde_yaml_bw::{from_str, Value, Error};
+
+#[test]
+fn test_error_includes_location_in_formats() {
+    // YAML starting with a literal block followed by invalid character to cause an error
+    let yaml = ">\n@";
+    let err = from_str::<Value>(yaml).unwrap_err();
+    let loc = err.location().expect("location not available");
+    assert_eq!(loc.line(), 2);
+    assert_eq!(loc.column(), 1);
+
+    let display = format!("{}", err);
+    let debug = format!("{:?}", err);
+    let pos_display = format!("line {} column {}", loc.line(), loc.column());
+    assert!(display.contains(&pos_display), "Display output missing location: {display}");
+
+    let pos_debug = format!("line: {}, column: {}", loc.line(), loc.column());
+    assert!(debug.contains(&pos_debug), "Debug output missing location: {debug}");
+}


### PR DESCRIPTION
## Summary
- add `tests/test_error_format.rs` verifying formatted error includes location info
- run `cargo check` and `cargo test`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68747ba30428832cb332fe9ee7051a85