### PR TITLE
Add error location test

### DIFF
--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -635,3 +635,11 @@ fn test_long_alias_chain_error() {
     );
 }
 
+#[test]
+fn test_error_location() {
+    let result = serde_yaml_bw::from_str::<Value>("@invalid_yaml");
+    let loc = result.unwrap_err().location().expect("location");
+    assert_eq!(1, loc.line());
+    assert_eq!(1, loc.column());
+}
+


### PR DESCRIPTION
## Summary
- add `test_error_location` verifying `Error::location`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68747bb3ace8832cad44e132c5f3d9dc