### PR TITLE
Add tests for Value indexing behavior

### DIFF
--- a/tests/test_value_indexing.rs
+++ b/tests/test_value_indexing.rs
@@ -1,0 +1,20 @@
+use serde_yaml_bw::Value;
+
+#[test]
+fn sequence_indexing() {
+    let yaml = "- a\n- b";
+    let value: Value = serde_yaml_bw::from_str(yaml).unwrap();
+
+    assert_eq!(value[0], Value::from("a"));
+    assert_eq!(value[2], Value::Null(None));
+}
+
+#[test]
+fn mapping_indexing() {
+    let yaml = "k: v";
+    let value: Value = serde_yaml_bw::from_str(yaml).unwrap();
+
+    assert_eq!(value["k"], Value::from("v"));
+    assert_eq!(value["missing"], Value::Null(None));
+    assert_eq!(value[0], Value::Null(None));
+}


### PR DESCRIPTION
## Summary
- add regression tests for `Value` indexing

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68747bb42e88832c830ab76170318e5f