### PR TITLE
Add apply_merge example test

### DIFF
--- a/tests/test_apply_merge.rs
+++ b/tests/test_apply_merge.rs
@@ -1,0 +1,23 @@
+use indoc::indoc;
+use serde_yaml_bw::Value;
+
+#[test]
+fn test_apply_merge_example() {
+    let config = indoc! {r#"
+        tasks:
+          build: &webpack_shared
+            command: webpack
+            args: build
+            inputs:
+              - 'src/**/*'
+          start:
+            <<: *webpack_shared
+            args: start
+    "#};
+
+    let mut value: Value = serde_yaml_bw::from_str(config).unwrap();
+    value.apply_merge().unwrap();
+
+    assert_eq!(value["tasks"]["start"]["command"], "webpack");
+    assert_eq!(value["tasks"]["start"]["args"], "start");
+}


### PR DESCRIPTION
## Summary
- add regression test for `Value::apply_merge`
- parse YAML from the `apply_merge` docs and verify merged fields

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68747b86dcc0832cadc33a7081621308