### PR TITLE
Add entry API unit tests for Mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,44 +43,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "libc"
-version = "0.2.174"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -156,7 +116,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sysinfo",
  "unsafe-libyaml",
 ]
 
@@ -172,20 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab138f5c1bb35231de19049060a87977ad23e04f2303e953bc5c2947ac7dec4"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,136 +141,3 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ itoa = "1.0"
 ryu = "1.0"
 serde = "1.0"
 unsafe-libyaml = "0.2.11"
-sysinfo = "0.36"# Checks safely alocatable memory
 
 [dev-dependencies]
 anyhow = "1.0" # All range tested

--- a/src/de.rs
+++ b/src/de.rs
@@ -860,7 +860,6 @@ impl<'de> de::MapAccess<'de> for MapAccess<'de, '_, '_> {
 
 struct EnumAccess<'de, 'document, 'variant> {
     de: &'variant mut DeserializerFromEvents<'de, 'document>,
-    name: Option<&'static str>,
     tag: &'document str,
 }
 
@@ -1386,7 +1385,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                         *self.pos -= 1;
                         break visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: None,
                             tag,
                         });
                     }
@@ -1397,7 +1395,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                         *self.pos -= 1;
                         break visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: None,
                             tag,
                         });
                     }
@@ -1408,7 +1405,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                         *self.pos -= 1;
                         break visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: None,
                             tag,
                         });
                     }
@@ -1898,7 +1894,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                 if let Some(tag) = parse_tag(scalar.value.tag.as_ref()) {
                     return visitor.visit_enum(EnumAccess {
                         de: self,
-                        name: Some(name),
                         tag,
                     });
                 }
@@ -1908,7 +1903,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                 if let Some(tag) = parse_tag(mapping.tag.as_ref()) {
                     return visitor.visit_enum(EnumAccess {
                         de: self,
-                        name: Some(name),
                         tag,
                     });
                 }
@@ -1943,7 +1937,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                 };
                 let result = visitor.visit_enum(EnumAccess {
                     de: self,
-                    name: Some(name),
                     tag,
                 });
                 let result = result.and_then(|v| {
@@ -1956,7 +1949,6 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
                     if let Some(tag) = parse_tag(sequence.tag.as_ref()) {
                         return visitor.visit_enum(EnumAccess {
                             de: self,
-                            name: Some(name),
                             tag,
                         });
                     }

--- a/src/duplicate_key.rs
+++ b/src/duplicate_key.rs
@@ -109,5 +109,11 @@ mod tests {
         let err = DuplicateKeyError::from_scalar(b"42");
         assert!(matches!(err.kind, DuplicateKeyKind::Number(n) if n == Number::from(42)));
     }
+
+    #[test]
+    fn test_display() {
+        let err = DuplicateKeyError::from_scalar(b"dup");
+        assert_eq!(format!("{}", err), "duplicate entry with key \"dup\"");
+    }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/serde_yaml/0.9.34+deprecated")]
+#![doc(html_root_url = "https://docs.rs/serde_yaml_bw/2.0.3")]
 #![deny(missing_docs, unsafe_op_in_unsafe_fn)]
 // Suppressed clippy_pedantic lints
 #![allow(

--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -76,7 +76,7 @@ where
         let pin = unsafe {
             let emitter = addr_of_mut!((*owned.ptr).sys);
             if sys::yaml_emitter_initialize(emitter).fail {
-                return Err(Error::Libyaml(libyaml::Error::emit_error(emitter)));
+                return Err(Error::Libyaml(libyaml::error::Error::emit_error(emitter)));
             }
             sys::yaml_emitter_set_unicode(emitter, true);
             sys::yaml_emitter_set_width(emitter, -1);
@@ -170,7 +170,7 @@ where
                 Event::MappingEnd => sys::yaml_mapping_end_event_initialize(sys_event),
             };
             if initialize_status.fail {
-                return Err(Error::Libyaml(libyaml::Error::emit_error(emitter)));
+                return Err(Error::Libyaml(libyaml::error::Error::emit_error(emitter)));
             }
             if sys::yaml_emitter_emit(emitter, sys_event).fail {
                 return Err(self.error());
@@ -206,7 +206,7 @@ where
         if let Some(write_error) = emitter.write_error.take() {
             Error::Io(write_error)
         } else {
-            Error::Libyaml(unsafe { libyaml::Error::emit_error(&raw const emitter.sys) })
+            Error::Libyaml(unsafe { libyaml::error::Error::emit_error(&raw const emitter.sys) })
         }
     }
 }

--- a/src/libyaml/mod.rs
+++ b/src/libyaml/mod.rs
@@ -4,5 +4,3 @@ pub mod error;
 pub mod parser;
 pub mod tag;
 mod util;
-
-use self::error::Error;

--- a/tests/test_apply_merge.rs
+++ b/tests/test_apply_merge.rs
@@ -1,0 +1,23 @@
+use indoc::indoc;
+use serde_yaml_bw::Value;
+
+#[test]
+fn test_apply_merge_example() {
+    let config = indoc! {r#"
+        tasks:
+          build: &webpack_shared
+            command: webpack
+            args: build
+            inputs:
+              - 'src/**/*'
+          start:
+            <<: *webpack_shared
+            args: start
+    "#};
+
+    let mut value: Value = serde_yaml_bw::from_str(config).unwrap();
+    value.apply_merge().unwrap();
+
+    assert_eq!(value["tasks"]["start"]["command"], "webpack");
+    assert_eq!(value["tasks"]["start"]["args"], "start");
+}

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -635,3 +635,11 @@ fn test_long_alias_chain_error() {
     );
 }
 
+#[test]
+fn test_error_location() {
+    let result = serde_yaml_bw::from_str::<Value>("@invalid_yaml");
+    let loc = result.unwrap_err().location().expect("location");
+    assert_eq!(1, loc.line());
+    assert_eq!(1, loc.column());
+}
+

--- a/tests/test_error_format.rs
+++ b/tests/test_error_format.rs
@@ -1,0 +1,19 @@
+use serde_yaml_bw::{from_str, Value, Error};
+
+#[test]
+fn test_error_includes_location_in_formats() {
+    // YAML starting with a literal block followed by invalid character to cause an error
+    let yaml = ">\n@";
+    let err = from_str::<Value>(yaml).unwrap_err();
+    let loc = err.location().expect("location not available");
+    assert_eq!(loc.line(), 2);
+    assert_eq!(loc.column(), 1);
+
+    let display = format!("{}", err);
+    let debug = format!("{:?}", err);
+    let pos_display = format!("line {} column {}", loc.line(), loc.column());
+    assert!(display.contains(&pos_display), "Display output missing location: {display}");
+
+    let pos_debug = format!("line: {}, column: {}", loc.line(), loc.column());
+    assert!(debug.contains(&pos_debug), "Debug output missing location: {debug}");
+}

--- a/tests/test_io_helpers.rs
+++ b/tests/test_io_helpers.rs
@@ -1,0 +1,48 @@
+use serde_derive::{Deserialize, Serialize};
+use std::io::Cursor;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Point {
+    x: i32,
+}
+
+#[test]
+fn test_from_slice_and_multi() {
+    let bytes = b"x: 1\n";
+    let point: Point = serde_yaml_bw::from_slice(bytes).unwrap();
+    assert_eq!(point, Point { x: 1 });
+
+    let multi = b"---\nx: 1\n---\nx: 2\n";
+    let points: Vec<Point> = serde_yaml_bw::from_slice_multi(multi).unwrap();
+    assert_eq!(points, vec![Point { x: 1 }, Point { x: 2 }]);
+}
+
+#[test]
+fn test_from_reader_multi() {
+    let multi = b"---\nx: 1\n---\nx: 2\n".to_vec();
+    let cursor = Cursor::new(multi);
+    let points: Vec<Point> = serde_yaml_bw::from_reader_multi(cursor).unwrap();
+    assert_eq!(points, vec![Point { x: 1 }, Point { x: 2 }]);
+}
+
+#[test]
+fn test_to_writer_and_multi() {
+    let mut buf = Vec::new();
+    let point = Point { x: 1 };
+    serde_yaml_bw::to_writer(&mut buf, &point).unwrap();
+    assert_eq!(String::from_utf8(buf.clone()).unwrap(), "x: 1\n");
+
+    buf.clear();
+    let points = vec![Point { x: 1 }, Point { x: 2 }];
+    serde_yaml_bw::to_writer_multi(&mut buf, &points).unwrap();
+    assert_eq!(String::from_utf8(buf).unwrap(), "x: 1\n---\nx: 2\n");
+}
+
+#[test]
+fn test_error_location() {
+    let result: Result<Point, _> = serde_yaml_bw::from_str("@");
+    let err = result.unwrap_err();
+    let loc = err.location().expect("location missing");
+    assert_eq!(loc.line(), 1);
+    assert_eq!(loc.column(), 1);
+}

--- a/tests/test_mapping_entry.rs
+++ b/tests/test_mapping_entry.rs
@@ -1,0 +1,115 @@
+// Tests for Mapping::entry APIs
+use serde_yaml_bw::{Mapping, Value};
+use serde_yaml_bw::mapping::Entry;
+
+#[test]
+fn test_or_insert() {
+    let mut mapping = Mapping::new();
+    let ptr_first: *const Value = {
+        let first = mapping.entry("k".into()).or_insert(1.into());
+        assert_eq!(first.as_i64(), Some(1));
+        first as *const _
+    };
+    assert_eq!(mapping.len(), 1);
+
+    let ptr_second: *const Value = {
+        let second = mapping.entry("k".into()).or_insert(2.into());
+        assert_eq!(second.as_i64(), Some(1));
+        second as *const _
+    };
+    assert_eq!(mapping.len(), 1);
+    assert_eq!(ptr_first, ptr_second);
+}
+
+#[test]
+fn test_or_insert_with() {
+    let mut mapping = Mapping::new();
+    let ptr_first: *const Value = {
+        let first = mapping.entry("k".into()).or_insert_with(|| 1.into());
+        assert_eq!(first.as_i64(), Some(1));
+        first as *const _
+    };
+    assert_eq!(mapping.len(), 1);
+
+    let ptr_second: *const Value = {
+        let second = mapping.entry("k".into()).or_insert_with(|| 2.into());
+        assert_eq!(second.as_i64(), Some(1));
+        second as *const _
+    };
+    assert_eq!(mapping.len(), 1);
+    assert_eq!(ptr_first, ptr_second);
+}
+
+#[test]
+fn test_and_modify() {
+    let mut mapping = Mapping::new();
+    mapping.entry("k".into()).or_insert(1.into());
+
+    let ptr_result: *const Value = {
+        let result = mapping
+            .entry("k".into())
+            .and_modify(|v| *v = 2.into())
+            .or_insert(0.into());
+        assert_eq!(result.as_i64(), Some(2));
+        result as *const _
+    };
+    assert_eq!(mapping.len(), 1);
+    assert_eq!(ptr_result, mapping.get("k").unwrap() as *const _);
+}
+
+#[test]
+fn test_entry_and_modify() {
+    let mut map = Mapping::new();
+    map.insert("a".into(), 1.into());
+
+    match map.entry("a".into()).and_modify(|v| *v = 10.into()) {
+        Entry::Occupied(o) => assert_eq!(o.get(), &Value::from(10)),
+        Entry::Vacant(_) => panic!("expected occupied"),
+    }
+
+    match map.entry("b".into()) {
+        Entry::Vacant(e) => {
+            Entry::Vacant(e).or_insert(20.into());
+        }
+        Entry::Occupied(_) => panic!("expected vacant"),
+    }
+
+    match map.entry("c".into()) {
+        Entry::Vacant(e) => {
+            Entry::Vacant(e).or_insert_with(|| 30.into());
+        }
+        Entry::Occupied(_) => panic!("expected vacant"),
+    }
+
+    assert_eq!(map.get("a"), Some(&Value::from(10)));
+    assert_eq!(map.get("b"), Some(&Value::from(20)));
+    assert_eq!(map.get("c"), Some(&Value::from(30)));
+}
+
+#[test]
+fn test_retain() {
+    let mut map = Mapping::new();
+    map.insert("a".into(), 1.into());
+    map.insert("b".into(), 2.into());
+    map.insert("c".into(), 3.into());
+
+    map.retain(|_, v| v.as_i64().unwrap() % 2 == 1);
+
+    assert!(map.contains_key("a"));
+    assert!(!map.contains_key("b"));
+    assert!(map.contains_key("c"));
+    assert_eq!(map.len(), 2);
+}
+
+#[test]
+fn test_into_keys_values_order() {
+    let mut map = Mapping::new();
+    map.insert("x".into(), 1.into());
+    map.insert("y".into(), 2.into());
+
+    let keys: Vec<_> = map.clone().into_keys().collect();
+    assert_eq!(keys, vec![Value::from("x"), Value::from("y")]);
+
+    let values: Vec<_> = map.into_values().collect();
+    assert_eq!(values, vec![Value::from(1), Value::from(2)]);
+}

--- a/tests/test_tag_display.rs
+++ b/tests/test_tag_display.rs
@@ -1,0 +1,14 @@
+use serde_yaml_bw::value::Tag;
+
+#[test]
+fn tag_equality_ignores_leading_bang() {
+    let tag_plain = Tag::new("Thing").unwrap();
+    let tag_banged = Tag::new("!Thing").unwrap();
+    assert_eq!(tag_plain, tag_banged);
+}
+
+#[test]
+fn tag_display_includes_bang() {
+    let tag = Tag::new("Thing").unwrap();
+    assert_eq!(format!("{}", tag), "!Thing");
+}

--- a/tests/test_value_helpers.rs
+++ b/tests/test_value_helpers.rs
@@ -1,0 +1,76 @@
+use serde_yaml_bw::{Mapping, Number, Sequence, Value};
+
+#[test]
+fn test_value_accessors() {
+    let null = Value::Null(None);
+    assert!(null.is_null());
+    assert!(!null.is_bool());
+    assert!(!null.is_number());
+    assert!(!null.is_string());
+    assert_eq!(null.as_i64(), None);
+    assert_eq!(null.as_u64(), None);
+    assert_eq!(null.as_f64(), None);
+    assert_eq!(null.as_str(), None);
+
+    let boolean = Value::Bool(true, None);
+    assert!(!boolean.is_null());
+    assert!(boolean.is_bool());
+    assert!(!boolean.is_number());
+    assert!(!boolean.is_string());
+    assert_eq!(boolean.as_bool(), Some(true));
+    assert_eq!(boolean.as_i64(), None);
+    assert_eq!(boolean.as_u64(), None);
+    assert_eq!(boolean.as_f64(), None);
+    assert_eq!(boolean.as_str(), None);
+
+    let number_int = Value::Number(Number::from(10), None);
+    assert!(!number_int.is_null());
+    assert!(!number_int.is_bool());
+    assert!(number_int.is_number());
+    assert!(!number_int.is_string());
+    assert!(number_int.is_i64());
+    assert!(number_int.is_u64());
+    assert!(!number_int.is_f64());
+    assert_eq!(number_int.as_i64(), Some(10));
+    assert_eq!(number_int.as_u64(), Some(10));
+    assert_eq!(number_int.as_f64(), Some(10.0));
+    assert_eq!(number_int.as_str(), None);
+
+    let number_float = Value::Number(Number::from(1.25), None);
+    assert!(number_float.is_number());
+    assert!(!number_float.is_i64());
+    assert!(!number_float.is_u64());
+    assert!(number_float.is_f64());
+    assert_eq!(number_float.as_f64(), Some(1.25));
+    assert_eq!(number_float.as_i64(), None);
+    assert_eq!(number_float.as_u64(), None);
+
+    let string = Value::String("hello".to_owned(), None);
+    assert!(!string.is_null());
+    assert!(!string.is_bool());
+    assert!(!string.is_number());
+    assert!(string.is_string());
+    assert_eq!(string.as_str(), Some("hello"));
+    assert_eq!(string.as_i64(), None);
+    assert_eq!(string.as_u64(), None);
+    assert_eq!(string.as_f64(), None);
+}
+
+#[test]
+fn test_indexing_returns_null_when_absent() {
+    let mut map = Mapping::new();
+    map.insert(Value::String("a".into(), None), Value::Number(Number::from(1), None));
+    let map_val = Value::Mapping(map);
+
+    assert_eq!(map_val["a"], Value::Number(Number::from(1), None));
+    assert_eq!(map_val["missing"], Value::Null(None));
+
+    let seq = Sequence {
+        anchor: None,
+        elements: vec![Value::Bool(false, None)],
+    };
+    let seq_val = Value::Sequence(seq);
+
+    assert_eq!(seq_val[0], Value::Bool(false, None));
+    assert_eq!(seq_val[1], Value::Null(None));
+}

--- a/tests/test_value_index.rs
+++ b/tests/test_value_index.rs
@@ -1,0 +1,8 @@
+use serde_yaml_bw::Value;
+
+#[test]
+fn test_value_index_returns_null() {
+    let value: Value = serde_yaml_bw::from_str("{a: {b: 1}}" ).unwrap();
+    assert_eq!(value["a"]["c"], Value::Null(None));
+    assert_eq!(value["x"][0], Value::Null(None));
+}

--- a/tests/test_value_indexing.rs
+++ b/tests/test_value_indexing.rs
@@ -1,0 +1,20 @@
+use serde_yaml_bw::Value;
+
+#[test]
+fn sequence_indexing() {
+    let yaml = "- a\n- b";
+    let value: Value = serde_yaml_bw::from_str(yaml).unwrap();
+
+    assert_eq!(value[0], Value::from("a"));
+    assert_eq!(value[2], Value::Null(None));
+}
+
+#[test]
+fn mapping_indexing() {
+    let yaml = "k: v";
+    let value: Value = serde_yaml_bw::from_str(yaml).unwrap();
+
+    assert_eq!(value["k"], Value::from("v"));
+    assert_eq!(value["missing"], Value::Null(None));
+    assert_eq!(value[0], Value::Null(None));
+}

--- a/tests/test_writer_reader.rs
+++ b/tests/test_writer_reader.rs
@@ -1,5 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
 use serde::Deserialize as _;
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Point {
@@ -46,4 +47,20 @@ fn test_large_reader_input() {
     } else {
         panic!("Expected mapping");
     }
+}
+
+#[test]
+fn test_from_slice_map() {
+    let yaml = b"x: 1\ny: 2\n";
+    let m: HashMap<String, i32> = serde_yaml_bw::from_slice(yaml).unwrap();
+    assert_eq!(m.get("x"), Some(&1));
+}
+
+#[test]
+fn test_from_slice_multi_map() {
+    let yaml = b"---\nx: 1\n---\nx: 2\n";
+    let vals: Vec<HashMap<String, i32>> = serde_yaml_bw::from_slice_multi(yaml).unwrap();
+    assert_eq!(vals.len(), 2);
+    assert_eq!(vals[0].get("x"), Some(&1));
+    assert_eq!(vals[1].get("x"), Some(&2));
 }


### PR DESCRIPTION
## Summary
- resolve merge conflict with master and add tests
- cover `Mapping::entry` methods: `or_insert`, `or_insert_with`, and `and_modify`

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68747ba01d1c832c8195f0f70ebe1ab6