### PR TITLE
Fix Cow string conversion and lossless UTF-8 handling

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1053,7 +1053,7 @@ fn parse_bool(scalar: &str) -> Option<bool> {
 fn parse_scalar_value(scalar: &ScalarEvent) -> Value {
     let anchor = scalar.anchor.clone();
     let Ok(repr) = std::str::from_utf8(&scalar.value.value) else {
-        return Value::String(String::from_utf8_lossy(&scalar.value.value).to_string(), anchor);
+        return Value::String(String::from_utf8_lossy(&scalar.value.value).into_owned(), anchor);
     };
     if scalar.value.style == ScalarStyle::Plain {
         if parse_null(&scalar.value.value).is_some() {

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -92,7 +92,7 @@ impl<'a> From<Cow<'a, str>> for Value {
     /// let x: Value = s.into();
     /// ```
     fn from(f: Cow<'a, str>) -> Self {
-        Value::String(f.to_string(), None)
+        Value::String(f.into_owned(), None)
     }
 }
 


### PR DESCRIPTION
## Summary
- use `into_owned()` when converting `Cow<str>` to `Value::String`
- handle invalid UTF-8 with `into_owned()` in scalar parsing
- run `cargo check` and `cargo test`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68748889a350832cad7edd750364a315