### PR TITLE
Replace to_string with into_owned

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1053,7 +1053,7 @@ fn parse_bool(scalar: &str) -> Option<bool> {
 fn parse_scalar_value(scalar: &ScalarEvent) -> Value {
     let anchor = scalar.anchor.clone();
     let Ok(repr) = std::str::from_utf8(&scalar.value.value) else {
-        return Value::String(String::from_utf8_lossy(&scalar.value.value).to_string(), anchor);
+        return Value::String(String::from_utf8_lossy(&scalar.value.value).into_owned(), anchor);
     };
     if scalar.value.style == ScalarStyle::Plain {
         if parse_null(&scalar.value.value).is_some() {


### PR DESCRIPTION
## Summary
- avoid an extra allocation when decoding non-UTF8 scalars

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68748939c748832cb8e7850b501b5e85