### PR TITLE
Use iter collect in PartialOrd

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -429,8 +429,8 @@ impl Hash for Mapping {
 
 impl PartialOrd for Mapping {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let mut self_entries = Vec::from_iter(self);
-        let mut other_entries = Vec::from_iter(other);
+        let mut self_entries = self.iter().collect::<Vec<_>>();
+        let mut other_entries = other.iter().collect::<Vec<_>>();
 
         // Sort in an arbitrary order that is consistent with Value's PartialOrd
         // impl.


### PR DESCRIPTION
## Summary
- replace `Vec::from_iter` usage in `Mapping`'s `PartialOrd` impl with `iter().collect::<Vec<_>>()` for clarity

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6874889fe260832c8736aa0b0369c997