### PR TITLE
Implement Default and use mem::take

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -17,7 +17,6 @@ use crate::duplicate_key::DuplicateKeyError;
 use crate::value::{Value, Sequence, Mapping};
 use crate::number::Number;
 use std::io;
-use std::mem;
 use std::num::ParseIntError;
 use std::str;
 use std::sync::Arc;
@@ -73,6 +72,12 @@ pub(crate) enum Progress<'de> {
     Iterable(Loader<'de>),
     Document(Document<'de>),
     Fail(Arc<ErrorImpl>),
+}
+
+impl<'de> Default for Progress<'de> {
+    fn default() -> Self {
+        Progress::Str("")
+    }
 }
 
 impl<'de> Deserializer<'de> {
@@ -171,8 +176,7 @@ impl Iterator for Deserializer<'_> {
             _ => {}
         }
 
-        let dummy = Progress::Str("");
-        let input = mem::replace(&mut self.progress, dummy);
+        let input = std::mem::take(&mut self.progress);
         match Loader::new(input) {
             Ok(loader) => {
                 self.progress = Progress::Iterable(loader);

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -10,7 +10,6 @@ use serde::de::Visitor;
 use serde::ser::{self, Serializer as _};
 use std::fmt::{self, Display};
 use std::io;
-use std::mem;
 use std::num;
 use std::str;
 
@@ -58,6 +57,12 @@ enum State {
     CheckForDuplicateTag,
     FoundTag(String),
     AlreadyTagged,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::NothingInParticular
+    }
 }
 
 impl<W> Serializer<W>
@@ -148,7 +153,7 @@ where
     }
 
     fn take_tag(&mut self) -> Option<String> {
-        let state = mem::replace(&mut self.state, State::NothingInParticular);
+        let state = std::mem::take(&mut self.state);
         if let State::FoundTag(mut tag) = state {
             if !tag.starts_with('!') {
                 tag.insert(0, '!');


### PR DESCRIPTION
## Summary
- implement `Default` for `Progress` and `State`
- use `std::mem::take` instead of `mem::replace`

## Testing
- `cargo check -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687488d37cdc832c838b4be2aebfe947