### PR TITLE
Remove direct serde_derive usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
- "serde_derive",
  "serde_json",
  "unsafe-libyaml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,12 @@ repository = "https://github.com/bourumir-wyngs/serde-yaml-bw"
 indexmap = ">=2.0, <=2.10"# All range tested
 itoa = "1.0"
 ryu = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 unsafe-libyaml = "0.2.11"
 
 [dev-dependencies]
 anyhow = "1.0" # All range tested
 indoc = "2.0"
-serde_derive = "1.0"
 serde_json = "1.0"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ handling:
 
 ```rust
 use serde::Deserialize;
-use serde_derive::Deserialize;
 use serde_yaml_bw::Deserializer;
 
 // Define the structure representing your YAML data.
@@ -64,7 +63,7 @@ fn main() {
 ```
 Here is example with merge keys (inherited properties):
 ```rust
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 /// Configuration to parse into. Does not include "defaults"
 #[derive(Debug, Deserialize, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! Structs serialize in the obvious way:
 //!
 //! ```ignore
-//! # use serde_derive::{Serialize, Deserialize};
+//! # use serde::{Serialize, Deserialize};
 //! use serde::{Serialize, Deserialize};
 //!
 //! #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -66,7 +66,7 @@
 //! Enums serialize using a YAML map whose key is the variant name.
 //!
 //! ```ignore
-//! # use serde_derive::{Serialize, Deserialize};
+//! # use serde::{Serialize, Deserialize};
 //! use serde::{Serialize, Deserialize};
 //!
 //! #[derive(Serialize, Deserialize, PartialEq, Debug)]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -58,8 +58,7 @@ pub enum Value {
 /// # Examples
 ///
 /// ```
-/// # use serde_derive::Deserialize;
-/// use serde::Deserialize;
+/// # use serde::Deserialize;
 /// use serde_yaml_bw::Value;
 ///
 /// #[derive(Deserialize)]

--- a/tests/test_anchor_only.rs
+++ b/tests/test_anchor_only.rs
@@ -1,5 +1,5 @@
 use indoc::indoc;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 #[derive(Debug, PartialEq, Deserialize)]
 struct Node {

--- a/tests/test_block_scalars.rs
+++ b/tests/test_block_scalars.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 use indoc::indoc;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use serde_yaml_bw::Value;
 
 #[derive(Debug, Deserialize, PartialEq)]

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -7,8 +7,7 @@
 )]
 
 use indoc::indoc;
-use serde_derive::Deserialize;
-use serde::Deserialize as _;
+use serde::Deserialize;
 use serde_yaml_bw::{Deserializer, Number, Value};
 use std::collections::BTreeMap;
 use std::fmt::Debug;

--- a/tests/test_end_marker.rs
+++ b/tests/test_end_marker.rs
@@ -1,4 +1,4 @@
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Person {

--- a/tests/test_enum_alias_nested.rs
+++ b/tests/test_enum_alias_nested.rs
@@ -1,7 +1,6 @@
 use indoc::indoc;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use serde_yaml_bw::{Deserializer};
-use serde::Deserialize as _;
 use std::fmt::Debug;
 
 fn test_de<T>(yaml: &str, expected: &T)

--- a/tests/test_enum_external.rs
+++ b/tests/test_enum_external.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use indoc::indoc;
-use serde_derive::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_yaml_bw;
 use std::fmt::Debug;
 

--- a/tests/test_enum_repetition_limit.rs
+++ b/tests/test_enum_repetition_limit.rs
@@ -1,6 +1,6 @@
 use indoc::indoc;
 use serde::de::Deserialize;
-use serde_derive::Deserialize as Derive;
+use serde::Deserialize as Derive;
 use serde_yaml_bw::Deserializer;
 use std::collections::BTreeMap;
 use std::fmt::Debug;

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::zero_sized_map_values)]
 
 use indoc::indoc;
-use serde::de::Deserialize;
 #[cfg(not(miri))]
 use serde::de::{SeqAccess, Visitor};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use serde_yaml_bw::{Deserializer, Value};
 #[cfg(not(miri))]

--- a/tests/test_historical_failures.rs
+++ b/tests/test_historical_failures.rs
@@ -1,6 +1,6 @@
 use serde_yaml_bw;
 use std::collections::HashMap;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 #[test]
 fn test_recursive_yaml_references_fail() {

--- a/tests/test_io_helpers.rs
+++ b/tests/test_io_helpers.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/tests/test_merge_cycle.rs
+++ b/tests/test_merge_cycle.rs
@@ -1,5 +1,5 @@
 use serde_yaml_bw::{from_str, from_str_value_preserve, Value};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[test]
 fn test_self_referential_merge() {

--- a/tests/test_merge_keys_serde.rs
+++ b/tests/test_merge_keys_serde.rs
@@ -1,4 +1,4 @@
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 /// Configuration to parse into. Does not include "defaults"
 #[derive(Debug, Deserialize, PartialEq)]

--- a/tests/test_multi_helpers.rs
+++ b/tests/test_multi_helpers.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use indoc::indoc;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/tests/test_no_panic.rs
+++ b/tests/test_no_panic.rs
@@ -1,6 +1,5 @@
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use serde_yaml_bw::{Deserializer, Value};
-use serde::Deserialize as _;
 
 #[test]
 fn null_key() {

--- a/tests/test_readme_examples.rs
+++ b/tests/test_readme_examples.rs
@@ -1,5 +1,4 @@
-use serde::Deserialize;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_yaml_bw::Deserializer;
 
 /// Test example 1 given in README

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -7,7 +7,7 @@
 
 use indoc::indoc;
 use serde::ser::SerializeMap;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_yaml_bw::{Mapping, Number, Sequence, Value};
 use std::collections::BTreeMap;
 use std::fmt::Debug;

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -7,7 +7,6 @@
 use indoc::indoc;
 use serde::de::IntoDeserializer;
 use serde::Deserialize;
-use serde_derive::{Deserialize, Serialize};
 use serde_yaml_bw::{Number, Value};
 
 #[test]

--- a/tests/test_writer_reader.rs
+++ b/tests/test_writer_reader.rs
@@ -1,5 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
-use serde::Deserialize as _;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- drop `serde_derive` dev dependency
- enable `derive` feature on `serde`
- update docs and tests to import macros from `serde`
- fix README examples

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6874887f5ca4832ca86ae80cf9c13eb7