### PR TITLE
Add test for default Mapping

### DIFF
--- a/tests/test_mapping_ops.rs
+++ b/tests/test_mapping_ops.rs
@@ -50,3 +50,10 @@ fn test_iterators() {
     let values: Vec<_> = map.values().map(|v| v.as_i64().unwrap()).collect();
     assert_eq!(values, [1, 2]);
 }
+
+#[test]
+fn test_default_map_empty() {
+    let map = Mapping::default();
+    assert!(map.is_empty());
+    assert_eq!(map.capacity(), 0);
+}


### PR DESCRIPTION
## Summary
- add a `test_default_map_empty` case verifying a default `Mapping` starts empty with zero capacity

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6874baaaf10c832ca8e0a4b39579617e