### PR TITLE
Add parsing tests for Number

### DIFF
--- a/tests/test_number_methods.rs
+++ b/tests/test_number_methods.rs
@@ -25,3 +25,27 @@ fn test_is_infinite_and_finite() {
     assert!(!finite.is_infinite());
     assert!(finite.is_finite());
 }
+
+#[test]
+fn test_parse_positive_integer() {
+    let n = "42".parse::<Number>().unwrap();
+    assert_eq!(n, Number::from(42));
+}
+
+#[test]
+fn test_parse_negative_integer() {
+    let n = "-42".parse::<Number>().unwrap();
+    assert_eq!(n, Number::from(-42));
+}
+
+#[test]
+fn test_parse_float() {
+    let n = "3.14".parse::<Number>().unwrap();
+    assert_eq!(n, Number::from(3.14));
+}
+
+#[test]
+fn test_parse_invalid() {
+    let err = "not_a_number".parse::<Number>().unwrap_err();
+    assert_eq!(err.to_string(), "failed to parse YAML number");
+}


### PR DESCRIPTION
## Summary
- extend `tests/test_number_methods.rs` to test parsing
- cover positive integers, negative integers, floats, and invalid strings

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6874ba9847b0832cbee120335eec093a