### PR TITLE
Add tests for parsing helpers

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1221,7 +1221,11 @@ fn parse_negative_int<T>(
     from_str_radix(scalar, 10).ok()
 }
 
-pub(crate) fn parse_f64(scalar: &str) -> Option<f64> {
+/// Parse a scalar as a floating point value.
+///
+/// Returns `Some(f64)` if the string is a valid finite float or special value
+/// like `.inf`. Otherwise returns `None`.
+pub fn parse_f64(scalar: &str) -> Option<f64> {
     let unpositive = if let Some(unpositive) = scalar.strip_prefix('+') {
         if unpositive.starts_with(['+', '-']) {
             return None;
@@ -1247,7 +1251,10 @@ pub(crate) fn parse_f64(scalar: &str) -> Option<f64> {
     None
 }
 
-pub(crate) fn digits_but_not_number(scalar: &str) -> bool {
+/// Check if a digit string should be treated as a YAML string rather than a number.
+///
+/// Leading zeros like `"00"` mean the scalar is not parsed as a numeric value.
+pub fn digits_but_not_number(scalar: &str) -> bool {
     // Leading zero(s) followed by numeric characters is a string according to
     // the YAML 1.2 spec. https://yaml.org/spec/1.2/spec.html#id2761292
     let scalar = scalar.strip_prefix(['-', '+']).unwrap_or(scalar);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 
 pub use crate::de::{
     from_reader, from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi,
-    from_str_value_preserve, Deserializer,
+    from_str_value_preserve, digits_but_not_number, parse_f64, Deserializer,
 };
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{

--- a/tests/test_de_helpers.rs
+++ b/tests/test_de_helpers.rs
@@ -1,0 +1,15 @@
+use serde_yaml_bw::{digits_but_not_number, parse_f64};
+
+#[test]
+fn test_digits_but_not_number() {
+    assert!(digits_but_not_number("00"));
+    assert!(digits_but_not_number("01"));
+    assert!(!digits_but_not_number("0"));
+}
+
+#[test]
+fn test_parse_f64_inf_and_invalid() {
+    assert_eq!(parse_f64(".inf"), Some(f64::INFINITY));
+    assert_eq!(parse_f64("inf"), None);
+    assert_eq!(parse_f64("not a number"), None);
+}


### PR DESCRIPTION
## Summary
- add integration tests covering `digits_but_not_number` and `parse_f64`
- expose these helper functions publicly for testing

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6874ba860730832c8b6e8c46a2616522