### PR TITLE
Add nested Value indexing tests

### DIFF
--- a/tests/test_value_indexing.rs
+++ b/tests/test_value_indexing.rs
@@ -18,3 +18,14 @@ fn mapping_indexing() {
     assert_eq!(value["missing"], Value::Null(None));
     assert_eq!(value[0], Value::Null(None));
 }
+
+#[test]
+fn nested_indexing() {
+    let yaml = "a:\n  - b\n  - c";
+    let value: Value = serde_yaml_bw::from_str(yaml).unwrap();
+
+    assert_eq!(value["a"][0], Value::from("b"));
+    assert_eq!(value["a"][5], Value::Null(None));
+    assert_eq!(value["a"]["missing"], Value::Null(None));
+    assert_eq!(value["missing"][0], Value::Null(None));
+}


### PR DESCRIPTION
## Summary
- extend `tests/test_value_indexing.rs` with nested indexing assertions
- ensure indexing out-of-bounds or with wrong types yields `Value::Null`

## Testing
- `cargo build`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6874ba89d540832cb00b3385d4aaeb98