### PR TITLE
Add starts_with method for Tag

### DIFF
--- a/src/value/tagged.rs
+++ b/src/value/tagged.rs
@@ -92,6 +92,14 @@ impl Tag {
         }
         Ok(Tag { string: tag })
     }
+
+    /// Determine whether this tag begins with the given prefix.
+    ///
+    /// The leading `!` on either the tag or the prefix is ignored when
+    /// determining whether the prefix matches.
+    pub fn starts_with(&self, prefix: &str) -> bool {
+        nobang(&self.string).starts_with(nobang(prefix))
+    }
 }
 
 impl Value {

--- a/tests/test_tag_starts_with.rs
+++ b/tests/test_tag_starts_with.rs
@@ -1,0 +1,11 @@
+use serde_yaml_bw::value::Tag;
+
+#[test]
+fn tag_starts_with_prefix_variants() {
+    let tag_with_bang = Tag::new("!Thing").unwrap();
+    let tag_without_bang = Tag::new("Thing").unwrap();
+    assert!(tag_with_bang.starts_with("!Th"));
+    assert!(tag_with_bang.starts_with("Th"));
+    assert!(tag_without_bang.starts_with("!Th"));
+    assert!(tag_without_bang.starts_with("Th"));
+}


### PR DESCRIPTION
## Summary
- add `Tag::starts_with` implementation
- test `starts_with` with tags both with and without leading `!`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6874baaac398832c985a6134f7665e25