### PR TITLE
Add default sequence test

### DIFF
--- a/tests/test_value_helpers.rs
+++ b/tests/test_value_helpers.rs
@@ -74,3 +74,11 @@ fn test_indexing_returns_null_when_absent() {
     assert_eq!(seq_val[0], Value::Bool(false, None));
     assert_eq!(seq_val[1], Value::Null(None));
 }
+
+#[test]
+fn test_sequence_default() {
+    let seq = Sequence::default();
+    assert_eq!(None, seq.anchor);
+    assert!(seq.elements.is_empty());
+    assert_eq!(seq, Sequence::new());
+}


### PR DESCRIPTION
## Summary
- cover `Sequence::default()` behavior in `test_value_helpers`
- verify default state and equivalence to `Sequence::new()`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6874ba72194c832c8461fd4172c48bcc