### PR TITLE
Add unknown anchor test

### DIFF
--- a/tests/test_resolve_aliases.rs
+++ b/tests/test_resolve_aliases.rs
@@ -1,0 +1,9 @@
+use serde_yaml_bw::{from_str_value_preserve};
+
+#[test]
+fn test_unknown_anchor_in_from_str_value_preserve() {
+    let yaml = "*some";
+    let err = from_str_value_preserve(yaml).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("unknown anchor"), "unexpected error: {msg}");
+}


### PR DESCRIPTION
## Summary
- add `tests/test_resolve_aliases.rs` to confirm that `from_str_value_preserve` fails with an "unknown anchor" error when parsing an alias with no anchor

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6874c6921080832c82676d4cbaf9c22a