### PR TITLE
Add failing test for unresolved alias

### DIFF
--- a/tests/test_resolve_aliases.rs
+++ b/tests/test_resolve_aliases.rs
@@ -1,0 +1,9 @@
+use serde_yaml_bw::{from_str_value_preserve, Value};
+
+#[test]
+fn unresolved_alias_returns_err() {
+    let yaml = "a: *missing";
+    let mut value: Value = from_str_value_preserve(yaml).unwrap();
+    let err = value.resolve_aliases().unwrap_err();
+    assert_eq!(err.to_string(), "unresolved alias");
+}


### PR DESCRIPTION
## Summary
- add a unit test for `Value::resolve_aliases` with an undefined anchor

## Testing
- `cargo check`
- `cargo test -- --test-threads=1` *(fails: unresolved_alias_returns_err)*

------
https://chatgpt.com/codex/tasks/task_e_6874ba56dae0832c8fc67e25bfeec4a1