### PR TITLE
Clarify default serializer state

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -53,6 +53,8 @@ where
 }
 
 enum State {
+    /// Serializer is idle and no special handling is in progress. This
+    /// variant is returned by `Default`.
     NothingInParticular,
     CheckForTag,
     CheckForDuplicateTag,
@@ -62,6 +64,7 @@ enum State {
 
 impl Default for State {
     fn default() -> Self {
+        // New serializers start out with no special state.
         State::NothingInParticular
     }
 }


### PR DESCRIPTION
## Summary
- document that `State::NothingInParticular` is the default serializer state
- note that new serializers start in this idle state

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6874d2c52efc832c80c37fd85e229fa6