### PR TITLE
Refactor base64 decoding

### DIFF
--- a/src/base64.rs
+++ b/src/base64.rs
@@ -1,0 +1,56 @@
+pub fn decode_base64(input: &str) -> Option<Vec<u8>> {
+    let mut cleaned = Vec::with_capacity(input.len());
+    for b in input.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/' | b'=' => cleaned.push(b),
+            b' ' | b'\n' | b'\r' | b'\t' => {}
+            _ => return None,
+        }
+    }
+    if cleaned.len() % 4 != 0 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(cleaned.len() / 4 * 3);
+    let mut i = 0;
+    while i < cleaned.len() {
+        let c0 = cleaned[i];
+        let c1 = cleaned[i + 1];
+        let c2 = cleaned[i + 2];
+        let c3 = cleaned[i + 3];
+        let v0 = decode_b64_char(c0)?;
+        let v1 = decode_b64_char(c1)?;
+        if c2 == b'=' {
+            if c3 != b'=' || i + 4 != cleaned.len() {
+                return None;
+            }
+            out.push((v0 << 2) | (v1 >> 4));
+            break;
+        }
+        let v2 = decode_b64_char(c2)?;
+        if c3 == b'=' {
+            if i + 4 != cleaned.len() {
+                return None;
+            }
+            out.push((v0 << 2) | (v1 >> 4));
+            out.push(((v1 & 0xf) << 4) | (v2 >> 2));
+            break;
+        }
+        let v3 = decode_b64_char(c3)?;
+        out.push((v0 << 2) | (v1 >> 4));
+        out.push(((v1 & 0xf) << 4) | (v2 >> 2));
+        out.push(((v2 & 0x3) << 6) | v3);
+        i += 4;
+    }
+    Some(out)
+}
+
+fn decode_b64_char(c: u8) -> Option<u8> {
+    match c {
+        b'A'..=b'Z' => Some(c - b'A'),
+        b'a'..=b'z' => Some(c - b'a' + 26),
+        b'0'..=b'9' => Some(c - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
+    }
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -16,6 +16,7 @@ use std::rc::Rc;
 use crate::duplicate_key::DuplicateKeyError;
 use crate::value::{Value, Sequence, Mapping};
 use crate::number::Number;
+use crate::base64::decode_base64;
 use std::io;
 use std::mem;
 use std::num::ParseIntError;
@@ -1056,63 +1057,6 @@ fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
         "true" | "True" | "TRUE" => Some(true),
         "false" | "False" | "FALSE" => Some(false),
-        _ => None,
-    }
-}
-
-fn decode_base64(input: &str) -> Option<Vec<u8>> {
-    let mut cleaned = Vec::with_capacity(input.len());
-    for b in input.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/' | b'=' => cleaned.push(b),
-            b' ' | b'\n' | b'\r' | b'\t' => {}
-            _ => return None,
-        }
-    }
-    if cleaned.len() % 4 != 0 {
-        return None;
-    }
-    let mut out = Vec::with_capacity(cleaned.len() / 4 * 3);
-    let mut i = 0;
-    while i < cleaned.len() {
-        let c0 = cleaned[i];
-        let c1 = cleaned[i + 1];
-        let c2 = cleaned[i + 2];
-        let c3 = cleaned[i + 3];
-        let v0 = decode_b64_char(c0)?;
-        let v1 = decode_b64_char(c1)?;
-        if c2 == b'=' {
-            if c3 != b'=' || i + 4 != cleaned.len() {
-                return None;
-            }
-            out.push((v0 << 2) | (v1 >> 4));
-            break;
-        }
-        let v2 = decode_b64_char(c2)?;
-        if c3 == b'=' {
-            if i + 4 != cleaned.len() {
-                return None;
-            }
-            out.push((v0 << 2) | (v1 >> 4));
-            out.push(((v1 & 0xf) << 4) | (v2 >> 2));
-            break;
-        }
-        let v3 = decode_b64_char(c3)?;
-        out.push((v0 << 2) | (v1 >> 4));
-        out.push(((v1 & 0xf) << 4) | (v2 >> 2));
-        out.push(((v2 & 0x3) << 6) | v3);
-        i += 4;
-    }
-    Some(out)
-}
-
-fn decode_b64_char(c: u8) -> Option<u8> {
-    match c {
-        b'A'..=b'Z' => Some(c - b'A'),
-        b'a'..=b'z' => Some(c - b'a' + 26),
-        b'0'..=b'9' => Some(c - b'0' + 52),
-        b'+' => Some(62),
-        b'/' => Some(63),
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ mod loader;
 pub mod mapping;
 mod duplicate_key;
 mod number;
+mod base64;
 mod path;
 mod ser;
 pub mod value;

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,6 +1,7 @@
 use crate::value::tagged::{self, TagStringVisitor};
 use crate::value::TaggedValue;
 use crate::{number, Error, Mapping, Sequence, Value};
+use crate::base64::decode_base64;
 use serde::de::value::{BorrowedStrDeserializer, StrDeserializer};
 use serde::de::{
     self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Error as _, Expected, MapAccess,
@@ -129,63 +130,6 @@ impl Value {
             Value::Number(n, _) => n.deserialize_any(visitor),
             other => Err(other.invalid_type(&visitor)),
         }
-    }
-}
-
-fn decode_base64(input: &str) -> Option<Vec<u8>> {
-    let mut cleaned = Vec::with_capacity(input.len());
-    for b in input.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/' | b'=' => cleaned.push(b),
-            b' ' | b'\n' | b'\r' | b'\t' => {}
-            _ => return None,
-        }
-    }
-    if cleaned.len() % 4 != 0 {
-        return None;
-    }
-    let mut out = Vec::with_capacity(cleaned.len() / 4 * 3);
-    let mut i = 0;
-    while i < cleaned.len() {
-        let c0 = cleaned[i];
-        let c1 = cleaned[i + 1];
-        let c2 = cleaned[i + 2];
-        let c3 = cleaned[i + 3];
-        let v0 = decode_b64_char(c0)?;
-        let v1 = decode_b64_char(c1)?;
-        if c2 == b'=' {
-            if c3 != b'=' || i + 4 != cleaned.len() {
-                return None;
-            }
-            out.push((v0 << 2) | (v1 >> 4));
-            break;
-        }
-        let v2 = decode_b64_char(c2)?;
-        if c3 == b'=' {
-            if i + 4 != cleaned.len() {
-                return None;
-            }
-            out.push((v0 << 2) | (v1 >> 4));
-            out.push(((v1 & 0xf) << 4) | (v2 >> 2));
-            break;
-        }
-        let v3 = decode_b64_char(c3)?;
-        out.push((v0 << 2) | (v1 >> 4));
-        out.push(((v1 & 0xf) << 4) | (v2 >> 2));
-        out.push(((v2 & 0x3) << 6) | v3);
-        i += 4;
-    }
-    Some(out)
-}
-
-fn decode_b64_char(c: u8) -> Option<u8> {
-    match c {
-        b'A'..=b'Z' => Some(c - b'A'),
-        b'a'..=b'z' => Some(c - b'a' + 26),
-        b'0'..=b'9' => Some(c - b'0' + 52),
-        b'+' => Some(62),
-        b'/' => Some(63),
-        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize base64 decoding into new `base64` module
- reuse `decode_base64` in `de` and `value::de`

## Testing
- `cargo check --offline`
- `cargo test --offline`


------
https://chatgpt.com/codex/tasks/task_e_68751cdc62b8832ca733a6090eed7c03