### PR TITLE
Document binary scalar decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![crates.io](https://img.shields.io/crates/d/serde_yaml_bw.svg)](https://crates.io/crates/serde_yaml_bw)
 [![docs.rs](https://docs.rs/serde_yaml_bw/badge.svg)](https://docs.rs/serde_yaml_bw)
 
-This package is a fork of **serde-yaml**, designed to provide (mostly) panic-free operation. Specifically, it should not panic when encountering malformed YAML syntax. This makes the library suitable for safely parsing user-supplied YAML content. Our fork also supports merge keys, which reduce redundancy and verbosity by enabling the reuse of common key-value pairs across multiple mappings.
+This package is a fork of **serde-yaml**, designed to provide (mostly) panic-free operation. Specifically, it should not panic when encountering malformed YAML syntax. This makes the library suitable for safely parsing user-supplied YAML content. Our fork also supports merge keys, which reduce redundancy and verbosity by enabling the reuse of common key-value pairs across multiple mappings. It also decodes `!!binary` scalars, converting base64-encoded text into `Vec<u8>`.
 
 These extensions come at the cost of some API restrictions: write access to indices and mappings has been removed. Read access remains possible, with `Value::Null` returned on invalid access. Also, duplicate keys are not longer permitted in YAML, returning proper error message instead.
 
@@ -145,5 +145,23 @@ Inner:
 
     let value: Outer = Outer::deserialize(serde_yaml_bw::Deserializer::from_str(yaml)).unwrap();
     assert_eq!(value, Outer::Inner(Inner::Newtype(0)));
+}
+```
+
+### Binary scalars
+
+YAML values tagged with `!!binary` are automatically base64-decoded when deserializing into a `Vec<u8>`.
+
+```rust
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Blob {
+    data: Vec<u8>,
+}
+
+fn parse_blob() {
+    let blob: Blob = serde_yaml_bw::from_str("data: !!binary aGVsbG8=").unwrap();
+    assert_eq!(blob.data, b"hello");
 }
 ```


### PR DESCRIPTION
## Summary
- document base64 decoding of `!!binary` scalars in README
- add example showing deserialization into `Vec<u8>`

## Testing
- `cargo check --offline`
- `cargo test --offline`


------
https://chatgpt.com/codex/tasks/task_e_68751dde4a68832c84be5582719797f2