### PR TITLE
Implement serialize_bytes

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -383,8 +383,12 @@ where
         })
     }
 
-    fn serialize_bytes(self, _value: &[u8]) -> Result<()> {
-        Err(error::new(ErrorImpl::BytesUnsupported))
+    fn serialize_bytes(self, value: &[u8]) -> Result<()> {
+        let mut seq = self.serialize_seq(Some(value.len()))?;
+        for byte in value {
+            seq.serialize_element(byte)?;
+        }
+        seq.end()
     }
 
     fn serialize_unit(self) -> Result<()> {

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1,0 +1,8 @@
+use serde_yaml_bw as yaml;
+
+#[test]
+fn test_serialize_bytes() {
+    let bytes: &[u8] = &[1, 2, 3];
+    let s = yaml::to_string(&bytes).unwrap();
+    assert_eq!(s, "- 1\n- 2\n- 3\n");
+}


### PR DESCRIPTION
## Summary
- implement `serialize_bytes` in serializer
- add regression test for byte serialization

## Testing
- `cargo check` *(failed: failed to download from `https://index.crates.io`)*
- `cargo test` *(failed: failed to download from `https://index.crates.io`)*

------
https://chatgpt.com/codex/tasks/task_e_687525371730832c96914c391c789efd