### PR TITLE
Fix nested enum deserialization

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -478,6 +478,28 @@ impl<'de> Deserializer<'de> for Value {
                 },
                 value: None,
             },
+            Value::Mapping(map) => {
+                if map.len() == 1 {
+                    let (key, value) = map.into_iter().next().unwrap();
+                    match key {
+                        Value::String(var, _) => {
+                            tag = var;
+                            EnumDeserializer { tag: &tag, value: Some(value) }
+                        }
+                        other => {
+                            return Err(Error::invalid_type(
+                                other.unexpected(),
+                                &"string",
+                            ));
+                        }
+                    }
+                } else {
+                    return Err(Error::invalid_type(
+                        Value::Mapping(map).unexpected(),
+                        &"a Value::Tagged enum",
+                    ));
+                }
+            }
             other => {
                 return Err(Error::invalid_type(
                     other.unexpected(),
@@ -1019,6 +1041,28 @@ impl<'de> Deserializer<'de> for &'de Value {
                 tag: variant,
                 value: None,
             },
+            Value::Mapping(map) => {
+                if map.len() == 1 {
+                    let (key, value) = map.iter().next().unwrap();
+                    match key {
+                        Value::String(var, _) => EnumRefDeserializer {
+                            tag: var,
+                            value: Some(value),
+                        },
+                        other => {
+                            return Err(Error::invalid_type(
+                                other.unexpected(),
+                                &"string",
+                            ));
+                        }
+                    }
+                } else {
+                    return Err(Error::invalid_type(
+                        Value::Mapping(map.clone()).unexpected(),
+                        &"a Value::Tagged enum",
+                    ));
+                }
+            }
             other => {
                 return Err(Error::invalid_type(
                     other.unexpected(),

--- a/tests/test_readme_examples.rs
+++ b/tests/test_readme_examples.rs
@@ -102,7 +102,6 @@ enum Constraint {
 }
 
 #[test]
-#[ignore]
 fn deserialize_robot_moves() {
     let yaml = r#"
 - by: 10.0


### PR DESCRIPTION
## Summary
- allow enums represented as single-key mappings when deserializing `Value`
- unignore README example test for robot moves

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687545a0ef68832cb758a44d1e6b734a