### PR TITLE
Improve enum mapping error message

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -496,14 +496,14 @@ impl<'de> Deserializer<'de> for Value {
                 } else {
                     return Err(Error::invalid_type(
                         Value::Mapping(map).unexpected(),
-                        &"a Value::Tagged enum",
+                        &"a mapping with a single key for the enum variant",
                     ));
                 }
             }
             other => {
                 return Err(Error::invalid_type(
                     other.unexpected(),
-                    &"a Value::Tagged enum",
+                    &"a mapping with a single key for the enum variant",
                 ));
             }
         })
@@ -1059,14 +1059,14 @@ impl<'de> Deserializer<'de> for &'de Value {
                 } else {
                     return Err(Error::invalid_type(
                         Value::Mapping(map.clone()).unexpected(),
-                        &"a Value::Tagged enum",
+                        &"a mapping with a single key for the enum variant",
                     ));
                 }
             }
             other => {
                 return Err(Error::invalid_type(
                     other.unexpected(),
-                    &"a Value::Tagged enum",
+                    &"a mapping with a single key for the enum variant",
                 ));
             }
         })

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -228,6 +228,33 @@ fn test_variant_not_a_seq() {
 }
 
 #[test]
+fn test_enum_mapping_has_extra_keys() {
+    #[derive(Deserialize, Debug)]
+    enum Point {
+        Tuple(u8, u8, u8),
+        Struct { x: f64, y: f64 },
+    }
+    let yaml = indoc! {
+        "
+        Tuple:
+          - 0
+          - 0
+          - 0
+        Struct:
+          x: 1.0
+          y: 2.0
+        "
+    };
+    let result = Point::deserialize(Deserializer::from_str(yaml));
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("mapping with a single key for the enum variant"),
+        "unexpected message: {}",
+        msg
+    );
+}
+
+#[test]
 fn test_anchor_too_long() {
     use serde_yaml_bw::Value;
     const MAX: usize = 65_536;


### PR DESCRIPTION
## Summary
- clarify error when an enum isn't represented as a single-key mapping
- test new error message for enums with extra keys

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68755382fc00832c9f1fdd3456d562f2