### PR TITLE
Update apply_merge docs for alias resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ production:
     assert_eq!(parsed, expected);
 }
 ```
+When using `from_str_value_preserve` to obtain a raw `Value`, anchors and aliases
+are preserved. `apply_merge` expects these aliases to be resolved already, so
+invoke `resolve_aliases` before merging:
+
+```rust
+use serde_yaml_bw::{Value, from_str_value_preserve};
+
+let mut value: Value = from_str_value_preserve(yaml_input).unwrap();
+value.resolve_aliases().unwrap();
+value.apply_merge().unwrap();
+```
+
 It is possible to construct infinite recursion with merge keys in YAML (RecursionLimitExceeded error would be returned)
 
 ### Nested enums

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -736,6 +736,18 @@ impl Value {
     /// assert_eq!(value["tasks"]["start"]["command"], "webpack");
     /// assert_eq!(value["tasks"]["start"]["args"], "start");
     /// ```
+    ///
+    /// When loading YAML using [`from_str_value_preserve`] which keeps aliases
+    /// intact, call [`resolve_aliases`](Self::resolve_aliases) before this
+    /// method:
+    ///
+    /// ```
+    /// # use serde_yaml_bw::{Value, from_str_value_preserve};
+    /// # let yaml = "a: &id 1\nb: *id\n";
+    /// # let mut value: Value = from_str_value_preserve(yaml).unwrap();
+    /// value.resolve_aliases().unwrap();
+    /// value.apply_merge().unwrap();
+    /// ```
     pub fn apply_merge(&mut self) -> Result<(), Error> {
         use std::collections::HashSet;
         let mut stack = Vec::new();


### PR DESCRIPTION
## Summary
- document that `apply_merge` expects aliases to be resolved first
- show how to call `resolve_aliases` before `apply_merge`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6875e36cdbe0832c99323932866abc35