### PR TITLE
Add from_str_value helper

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -2141,3 +2141,12 @@ where
 pub fn from_str_value_preserve(s: &str) -> Result<Value> {
     Deserializer::from_str(s).de(|state| state.parse_value())
 }
+
+/// Deserialize a YAML `Value`, applying merges and resolving aliases.
+#[allow(clippy::redundant_closure_for_method_calls)]
+pub fn from_str_value(s: &str) -> Result<Value> {
+    let mut value = from_str_value_preserve(s)?;
+    value.resolve_aliases()?;
+    value.apply_merge()?;
+    Ok(value)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@
 
 pub use crate::de::{
     from_reader, from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi,
-    from_str_value_preserve, digits_but_not_number, parse_f64, Deserializer,
+    from_str_value_preserve, from_str_value, digits_but_not_number, parse_f64, Deserializer,
 };
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{

--- a/tests/test_from_str_value.rs
+++ b/tests/test_from_str_value.rs
@@ -1,0 +1,31 @@
+use indoc::indoc;
+use serde_yaml_bw::{from_str_value, Number, Value};
+
+#[test]
+fn test_from_str_value_resolves_alias() {
+    let yaml = "a: &id 1\nb: *id";
+    let value: Value = from_str_value(yaml).unwrap();
+
+    assert_eq!(value["b"], Value::Number(Number::from(1), None));
+}
+
+#[test]
+fn test_from_str_value_applies_merge() {
+    let yaml = indoc! {
+        r#"
+        defaults: &defaults
+          a: 1
+          b: 2
+
+        actual:
+          <<: *defaults
+          c: 3
+        "#
+    };
+
+    let value: Value = from_str_value(yaml).unwrap();
+
+    assert_eq!(value["actual"]["a"], Value::Number(Number::from(1), None));
+    assert_eq!(value["actual"]["b"], Value::Number(Number::from(2), None));
+    assert_eq!(value["actual"]["c"], Value::Number(Number::from(3), None));
+}


### PR DESCRIPTION
## Summary
- add `from_str_value` for resolving aliases and merges
- re-export the new helper
- test merge and alias behaviour when using `from_str_value`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6875e987a710832c99b324e7505823f8