### PR TITLE
Implement total ordering for Number

### DIFF
--- a/tests/test_number_ordering.rs
+++ b/tests/test_number_ordering.rs
@@ -1,0 +1,17 @@
+use serde_yaml_bw::Number;
+use std::cmp::Ordering;
+
+#[test]
+fn test_ordering_between_int_and_float() {
+    assert_eq!(Number::from(2).partial_cmp(&Number::from(2.0)), Some(Ordering::Equal));
+    assert!(Number::from(1) < Number::from(1.5));
+    assert!(Number::from(3) > Number::from(2.5));
+    assert!(Number::from(-3) < Number::from(-2.5));
+}
+
+#[test]
+fn test_ordering_special_values() {
+    assert!(Number::from(f64::INFINITY) > Number::from(1));
+    assert!(Number::from(f64::NEG_INFINITY) < Number::from(0));
+    assert!(Number::from(f64::NAN) > Number::from(0));
+}


### PR DESCRIPTION
## Summary
- implement comparison between integers and floats
- add helper `cmp_int_float`
- document ordering rules
- test ordering across numeric types

## Testing
- `cargo check`
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6878af98b2d8832c93f075e7f13f9d1c