### PR TITLE
Introduce DEFAULT_RECURSION_LIMIT constant

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -26,6 +26,9 @@ use base64::prelude::BASE64_STANDARD;
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Default recursion limit for deserialization.
+const DEFAULT_RECURSION_LIMIT: u8 = 128;
+
 /// A structure that deserializes YAML into Rust values.
 ///
 /// # Examples
@@ -125,7 +128,7 @@ impl<'de> Deserializer<'de> {
                     pos: &mut pos,
                     jumpcount: &mut jumpcount,
                     path: Path::Root,
-                    remaining_depth: 128,
+                    remaining_depth: DEFAULT_RECURSION_LIMIT,
                     enum_depth: Rc::clone(&enum_depth),
                 })?;
                 if let Some(parse_error) = document.error {
@@ -145,7 +148,7 @@ impl<'de> Deserializer<'de> {
             pos: &mut pos,
             jumpcount: &mut jumpcount,
             path: Path::Root,
-            remaining_depth: 128,
+            remaining_depth: DEFAULT_RECURSION_LIMIT,
             enum_depth: Rc::clone(&enum_depth),
         })?;
         if let Some(parse_error) = document.error {

--- a/tests/test_recursion_limit.rs
+++ b/tests/test_recursion_limit.rs
@@ -1,0 +1,13 @@
+use serde_yaml_bw::Value;
+
+#[test]
+fn test_recursion_limit_exceeded() {
+    let depth = 129;
+    let yaml = "[".repeat(depth) + &"]".repeat(depth);
+    let err = serde_yaml_bw::from_str::<Value>(&yaml).unwrap_err();
+    assert!(
+        err.to_string().starts_with("recursion limit exceeded"),
+        "unexpected error: {}",
+        err
+    );
+}


### PR DESCRIPTION
## Summary
- define a `DEFAULT_RECURSION_LIMIT` constant
- use the constant when initializing `remaining_depth`
- add a regression test for exceeding the recursion limit

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6878af8a021c832c8ba3f90a69d7a545