### PR TITLE
Add case-insensitive bool parsing helper

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1055,11 +1055,7 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
 }
 
 fn parse_bool(scalar: &str) -> Option<bool> {
-    match scalar {
-        "true" | "True" | "TRUE" => Some(true),
-        "false" | "False" | "FALSE" => Some(false),
-        _ => None,
-    }
+    parse_bool_casefold(scalar)
 }
 
 fn parse_scalar_value(scalar: &ScalarEvent) -> Value {
@@ -1261,6 +1257,17 @@ pub fn parse_f64(scalar: &str) -> Option<f64> {
         }
     }
     None
+}
+
+/// Parse a scalar as a boolean using ASCII case-insensitive matching.
+pub fn parse_bool_casefold(s: &str) -> Option<bool> {
+    if s.eq_ignore_ascii_case("true") {
+        Some(true)
+    } else if s.eq_ignore_ascii_case("false") {
+        Some(false)
+    } else {
+        None
+    }
 }
 
 /// Check if a digit string should be treated as a YAML string rather than a number.

--- a/src/duplicate_key.rs
+++ b/src/duplicate_key.rs
@@ -52,11 +52,7 @@ fn is_null(s: &[u8]) -> bool {
 }
 
 fn parse_bool(s: &str) -> Option<bool> {
-    match s {
-        "true" | "True" | "TRUE" => Some(true),
-        "false" | "False" | "FALSE" => Some(false),
-        _ => None,
-    }
+    crate::de::parse_bool_casefold(s)
 }
 
 impl Display for DuplicateKeyError {
@@ -75,7 +71,8 @@ impl Display for DuplicateKeyError {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_bool, is_null, DuplicateKeyError, DuplicateKeyKind};
+    use super::{is_null, DuplicateKeyError, DuplicateKeyKind};
+    use crate::parse_bool_casefold;
     use crate::number::Number;
 
     #[test]
@@ -89,13 +86,13 @@ mod tests {
 
     #[test]
     fn test_parse_bool_variants() {
-        assert_eq!(parse_bool("true"), Some(true));
-        assert_eq!(parse_bool("True"), Some(true));
-        assert_eq!(parse_bool("TRUE"), Some(true));
-        assert_eq!(parse_bool("false"), Some(false));
-        assert_eq!(parse_bool("False"), Some(false));
-        assert_eq!(parse_bool("FALSE"), Some(false));
-        assert_eq!(parse_bool("other"), None);
+        assert_eq!(parse_bool_casefold("true"), Some(true));
+        assert_eq!(parse_bool_casefold("True"), Some(true));
+        assert_eq!(parse_bool_casefold("TRUE"), Some(true));
+        assert_eq!(parse_bool_casefold("false"), Some(false));
+        assert_eq!(parse_bool_casefold("False"), Some(false));
+        assert_eq!(parse_bool_casefold("FALSE"), Some(false));
+        assert_eq!(parse_bool_casefold("other"), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,8 @@
 
 pub use crate::de::{
     from_reader, from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi,
-    from_str_value, digits_but_not_number, parse_f64, Deserializer,
+    from_str_value, digits_but_not_number, parse_bool_casefold, parse_f64,
+    Deserializer,
 };
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{

--- a/tests/test_de_helpers.rs
+++ b/tests/test_de_helpers.rs
@@ -1,4 +1,4 @@
-use serde_yaml_bw::{digits_but_not_number, parse_f64};
+use serde_yaml_bw::{digits_but_not_number, parse_bool_casefold, parse_f64};
 
 #[test]
 fn test_digits_but_not_number() {
@@ -12,4 +12,15 @@ fn test_parse_f64_inf_and_invalid() {
     assert_eq!(parse_f64(".inf"), Some(f64::INFINITY));
     assert_eq!(parse_f64("inf"), None);
     assert_eq!(parse_f64("not a number"), None);
+}
+
+#[test]
+fn test_parse_bool_casefold_variants() {
+    assert_eq!(parse_bool_casefold("true"), Some(true));
+    assert_eq!(parse_bool_casefold("True"), Some(true));
+    assert_eq!(parse_bool_casefold("TRUE"), Some(true));
+    assert_eq!(parse_bool_casefold("false"), Some(false));
+    assert_eq!(parse_bool_casefold("False"), Some(false));
+    assert_eq!(parse_bool_casefold("FALSE"), Some(false));
+    assert_eq!(parse_bool_casefold("other"), None);
 }


### PR DESCRIPTION
## Summary
- implement `parse_bool_casefold` for ASCII case-insensitive bool parsing
- replace `parse_bool` implementations to reuse `parse_bool_casefold`
- export the helper via crate root
- update helper tests and duplicate key tests

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6878af77b270832c9d824da2b8bad3c9