### PR TITLE
Improve error locations

### DIFF
--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -711,3 +711,20 @@ fn test_error_filters_control_chars() {
     );
 }
 
+#[test]
+fn test_from_str_value_duplicate_location() {
+    let yaml = "---\na: 1\na: 2\n";
+    let err = serde_yaml_bw::from_str_value(yaml).unwrap_err();
+    let loc = err.location().expect("location");
+    assert_eq!(2, loc.line());
+    assert_eq!(1, loc.column());
+}
+
+#[test]
+fn test_from_str_value_unexpected_end_location() {
+    let err = serde_yaml_bw::from_str_value("]").unwrap_err();
+    let loc = err.location().expect("location");
+    assert_eq!(1, loc.line());
+    assert_eq!(1, loc.column());
+}
+


### PR DESCRIPTION
## Summary
- ensure unexpected-end errors carry source location
- attach duplicate key locations for value deserialization
- add regression tests for these errors

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687a1edbece0832cb5242245656e8147