### PR TITLE
Add TagError doc comment

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,7 @@ pub(crate) enum ErrorImpl {
 
     Shared(Arc<ErrorImpl>),
     SerializedValueBeforeSerializeKey,
+    /// Indicates that an invalid YAML tag was encountered during serialization.
     TagError,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,12 @@
 //!     Ok(())
 //! }
 //! ```
+
+//! ## Errors
+//!
+//! Attempting to serialize a value with an invalid YAML tag will
+//! result in an [`Error`] whose cause is internally represented by the private
+//! `TagError` variant.
 //!
 //! ## Using Serde derive
 //!


### PR DESCRIPTION
## Summary
- document TagError in error module
- mention TagError in crate-level docs

## Testing
- `cargo check --verbose`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_687a1fa30ec8832c8b9299a57f246371