### PR TITLE
Add serde_repr integration test

### DIFF
--- a/tests/test_serde_repr.rs
+++ b/tests/test_serde_repr.rs
@@ -1,0 +1,19 @@
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde_yaml_bw as yaml;
+
+#[derive(Debug, PartialEq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+enum Example {
+    A = 1,
+    B = 2,
+}
+
+#[test]
+fn test_serde_repr_enum() {
+    let value = Example::B;
+    let yaml_str = "2\n";
+    let serialized = yaml::to_string(&value).unwrap();
+    assert_eq!(yaml_str, serialized);
+    let deserialized: Example = yaml::from_str(yaml_str).unwrap();
+    assert_eq!(value, deserialized);
+}


### PR DESCRIPTION
## Summary
- test serde_repr enums can be serialized and deserialized

## Testing
- `cargo check --tests`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ab6647e08832c9e7da58ff16a8b3e