### PR TITLE
Add yaml! macro for compile-time YAML

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ mod number;
 mod path;
 mod ser;
 pub mod value;
+mod macros;
 
 pub use crate::number::unexpected;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,148 @@
+/// Construct a `serde_yaml_bw::Value` from a YAML-like literal.
+#[macro_export]
+macro_rules! yaml {
+    ($($yaml:tt)+) => {
+        $crate::yaml_internal!($($yaml)+)
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! yaml_internal {
+    (@array [$($elems:expr,)*]) => {
+        $crate::yaml_internal_vec![$($elems,)*]
+    };
+    (@array [$($elems:expr),*]) => {
+        $crate::yaml_internal_vec![$($elems),*]
+    };
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        $crate::yaml_internal!(@array [$($elems,)* $crate::yaml_internal!(null)] $($rest)*)
+    };
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        $crate::yaml_internal!(@array [$($elems,)* $crate::yaml_internal!(true)] $($rest)*)
+    };
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        $crate::yaml_internal!(@array [$($elems,)* $crate::yaml_internal!(false)] $($rest)*)
+    };
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        $crate::yaml_internal!(@array [$($elems,)* $crate::yaml_internal!([$($array)*])] $($rest)*)
+    };
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        $crate::yaml_internal!(@array [$($elems,)* $crate::yaml_internal!({$($map)*})] $($rest)*)
+    };
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        $crate::yaml_internal!(@array [$($elems,)* $crate::yaml_internal!($next),] $($rest)*)
+    };
+    (@array [$($elems:expr,)*] $last:expr) => {
+        $crate::yaml_internal!(@array [$($elems,)* $crate::yaml_internal!($last)])
+    };
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        $crate::yaml_internal!(@array [$($elems,)*] $($rest)*)
+    };
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        $crate::yaml_unexpected!($unexpected)
+    };
+
+    (@object $object:ident () () ()) => {};
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        $crate::yaml_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        $crate::yaml_unexpected!($unexpected);
+    };
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object [$($key)+] ($crate::yaml_internal!(null)) $($rest)*);
+    };
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object [$($key)+] ($crate::yaml_internal!(true)) $($rest)*);
+    };
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object [$($key)+] ($crate::yaml_internal!(false)) $($rest)*);
+    };
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object [$($key)+] ($crate::yaml_internal!([$($array)*])) $($rest)*);
+    };
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object [$($key)+] ($crate::yaml_internal!({$($map)*})) $($rest)*);
+    };
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object [$($key)+] ($crate::yaml_internal!($value)) , $($rest)*);
+    };
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        $crate::yaml_internal!(@object $object [$($key)+] ($crate::yaml_internal!($value)));
+    };
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        $crate::yaml_internal!();
+    };
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        $crate::yaml_internal!();
+    };
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        $crate::yaml_unexpected!($colon);
+    };
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        $crate::yaml_unexpected!($comma);
+    };
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        $crate::yaml_expect_expr_comma!($($unexpected)+);
+    };
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        $crate::yaml_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    (null) => {
+        $crate::Value::Null(None)
+    };
+    (true) => {
+        $crate::Value::Bool(true, None)
+    };
+    (false) => {
+        $crate::Value::Bool(false, None)
+    };
+    ([]) => {
+        $crate::Value::Sequence($crate::Sequence { anchor: None, elements: $crate::yaml_internal_vec![] })
+    };
+    ([ $($tt:tt)+ ]) => {
+        $crate::Value::Sequence($crate::Sequence { anchor: None, elements: $crate::yaml_internal!(@array [] $($tt)+) })
+    };
+    ({}) => {
+        $crate::Value::Mapping($crate::Mapping::new())
+    };
+    ({ $($tt:tt)+ }) => {
+        $crate::Value::Mapping({
+            let mut object = $crate::Mapping::new();
+            $crate::yaml_internal!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+    ($other:expr) => {
+        $crate::to_value(&$other).unwrap()
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! yaml_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! yaml_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! yaml_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/tests/test_yaml_macro.rs
+++ b/tests/test_yaml_macro.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use serde_yaml_bw::{yaml, to_string, from_value};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Example {
+    alpha: u32,
+    beta: bool,
+}
+
+#[test]
+fn test_yaml_macro_basic() {
+    let value = yaml!({
+        "alpha": 1,
+        "beta": true,
+    });
+
+    let out = to_string(&value).unwrap();
+    assert_eq!(out, "alpha: 1\nbeta: true\n");
+
+    let s: Example = from_value(value).unwrap();
+    assert_eq!(s, Example { alpha: 1, beta: true });
+}


### PR DESCRIPTION
## Summary
- implement `yaml!` macro for building `Value` expressions
- expose macros through new module
- test macro functionality

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ff351e744832c937c864f6e70cbe3