### PR TITLE
Add yaml! macros for inline YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,5 +171,32 @@ fn parse_blob() {
 }
 ```
 
+### Macros
+
+Use the `yaml!` macro to embed YAML directly in your code. It parses the string
+at runtime and yields a `serde_yaml_bw::Value`. The `yaml_template!` macro works
+the same way but takes a format string with arguments for building YAML
+dynamically.
+
+```rust
+use serde::Deserialize;
+use serde_yaml_bw::{yaml, yaml_template};
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Config {
+    name: String,
+    count: u32,
+}
+
+let value = yaml!("name: John\ncount: 1");
+let cfg: Config = serde_yaml_bw::from_value(value).unwrap();
+assert_eq!(cfg, Config { name: "John".to_owned(), count: 1 });
+
+let user = "Jane";
+let value = yaml_template!("name: {user}\ncount: {n}", n = 2, user = user);
+let cfg: Config = serde_yaml_bw::from_value(value).unwrap();
+assert_eq!(cfg, Config { name: "Jane".to_owned(), count: 2 });
+```
+
 ### Rc, Arc, Box and Cow
 To serialize references ([`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html), [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html)), just add the [`"rc"` feature](https://serde.rs/feature-flags.html#-features-rc) to [Serde](https://serde.rs/). [`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) and [`Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html) are supported [out of the box](https://serde.rs/data-model.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ mod number;
 mod path;
 mod ser;
 pub mod value;
+mod macros;
 
 pub use crate::number::unexpected;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,34 @@
+/// Parse a YAML string slice into a [`Value`](crate::Value) at runtime.
+///
+/// # Panics
+///
+/// Panics if the input string is not valid YAML.
+#[macro_export]
+macro_rules! yaml {
+    ($yaml:expr $(,)?) => {{
+        match $crate::from_str::<$crate::Value>($yaml) {
+            Ok(v) => v,
+            Err(e) => panic!("yaml! macro failed to parse YAML: {e}"),
+        }
+    }};
+}
+
+/// Format a YAML string at runtime and parse it into a [`Value`](crate::Value).
+///
+/// This macro accepts a format string plus optional arguments in the same way
+/// as [`format!`]. The resulting string is parsed as YAML.
+///
+/// # Panics
+///
+/// Panics if the expanded string is not valid YAML.
+#[macro_export]
+macro_rules! yaml_template {
+    ($fmt:expr $(, $($arg:tt)+ )?) => {{
+        let s = format!($fmt $(, $($arg)+ )?);
+        match $crate::from_str::<$crate::Value>(&s) {
+            Ok(v) => v,
+            Err(e) => panic!("yaml_template! macro failed to parse YAML: {e}"),
+        }
+    }};
+}
+

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -1,0 +1,39 @@
+#![allow(clippy::uninlined_format_args)]
+use indoc::indoc;
+use serde::{Deserialize, Serialize};
+use serde_yaml_bw::{yaml, yaml_template, to_string};
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Config {
+    name: String,
+    count: u32,
+}
+
+#[test]
+fn test_yaml_macro() {
+    let value = yaml!(indoc!("\
+        name: John
+        count: 1
+    "));
+    let cfg: Config = serde_yaml_bw::from_value(value).unwrap();
+    assert_eq!(cfg, Config { name: "John".to_owned(), count: 1 });
+}
+
+#[test]
+fn test_yaml_template_macro() {
+    let user = "Jane";
+    let value = yaml_template!(indoc!("\
+        name: {user}
+        count: {c}
+    "), c = 2, user = user);
+    let cfg: Config = serde_yaml_bw::from_value(value).unwrap();
+    assert_eq!(cfg, Config { name: "Jane".to_owned(), count: 2 });
+}
+
+#[test]
+fn test_yaml_macro_serialization() {
+    let cfg = Config { name: "John".to_owned(), count: 1 };
+    let out = to_string(&cfg).unwrap();
+    assert_eq!(out, "name: John\ncount: 1\n");
+}
+


### PR DESCRIPTION
## Summary
- add `yaml!` and `yaml_template!` macros for embedding YAML
- document macros in README
- test new macros

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687ff3454780832ca80375d524d6fd4c