### PR TITLE
Implement streaming deserializer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@
 pub use crate::de::{
     from_reader, from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi,
     from_str_value, digits_but_not_number, parse_bool_casefold, parse_f64,
-    Deserializer,
+    Deserializer, StreamDeserializer,
 };
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{

--- a/tests/test_stream_deserializer.rs
+++ b/tests/test_stream_deserializer.rs
@@ -1,0 +1,16 @@
+use serde::Deserialize;
+use indoc::indoc;
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct Point {
+    x: i32,
+}
+
+#[test]
+fn test_stream_deserializer() {
+    let yaml = indoc!("---\nx: 1\n---\nx: 2\n");
+    let mut stream = serde_yaml_bw::Deserializer::from_str(yaml).into_iter::<Point>();
+    assert_eq!(stream.next().unwrap().unwrap(), Point { x: 1 });
+    assert_eq!(stream.next().unwrap().unwrap(), Point { x: 2 });
+    assert!(stream.next().is_none());
+}


### PR DESCRIPTION
## Summary
- expose a streaming deserializer similar to `serde_json::StreamDeserializer`
- export `StreamDeserializer` from the crate
- add a test for streaming deserialization

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ff31fbf88832c9a964385dc166fcc