### PR TITLE
Add customizable deserialization limits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@
 pub use crate::de::{
     from_reader, from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi,
     from_str_value, digits_but_not_number, parse_bool_casefold, parse_f64,
-    Deserializer,
+    Deserializer, DeserializerOptions,
 };
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{

--- a/tests/test_deserializer_options.rs
+++ b/tests/test_deserializer_options.rs
@@ -1,0 +1,31 @@
+use indoc::indoc;
+use serde::Deserialize;
+use serde_yaml_bw::{Deserializer, DeserializerOptions, Value};
+
+#[test]
+fn custom_recursion_limit_exceeded() {
+    let depth = 3;
+    let yaml = "[".repeat(depth) + &"]".repeat(depth);
+    let mut opts = DeserializerOptions::default();
+    opts.recursion_limit = 2;
+    let err = Value::deserialize(Deserializer::from_str_with_options(&yaml, &opts)).unwrap_err();
+    assert!(
+        err.to_string().starts_with("recursion limit exceeded"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn custom_alias_limit_exceeded() {
+    let yaml = indoc! {
+        "
+        first: &a 1
+        second: [*a, *a, *a]
+        "
+    };
+    let mut opts = DeserializerOptions::default();
+    opts.alias_limit = 2;
+    let result = Value::deserialize(Deserializer::from_str_with_options(yaml, &opts));
+    assert_eq!("repetition limit exceeded", result.unwrap_err().to_string());
+}


### PR DESCRIPTION
## Summary
- introduce `DeserializerOptions` for custom recursion and alias limits
- provide `Deserializer::from_*_with_options` constructors
- enforce options in deserializer internals
- add tests checking low limit errors

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ff2d58dd4832c950ba7a161f120de