### PR TITLE
Add SerializerBuilder and emitter options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use crate::de::{
 };
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{
-    to_string, to_string_multi, to_writer, to_writer_multi, Serializer,
+    to_string, to_string_multi, to_writer, to_writer_multi, Serializer, SerializerBuilder,
 };
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Number, Sequence, Value};

--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -49,7 +49,7 @@ pub(crate) struct Scalar<'a> {
     pub style: ScalarStyle,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum ScalarStyle {
     Any,
     Plain,
@@ -71,7 +71,7 @@ impl<W> Emitter<W>
 where
     W: io::Write,
 {
-    pub fn new(write: W) -> Result<Emitter<W>, Error> {
+    pub fn new(write: W, width: i32, indent: i32) -> Result<Emitter<W>, Error> {
         let owned = Owned::<EmitterPinned<W>>::new_uninit();
         let pin = unsafe {
             let emitter = addr_of_mut!((*owned.ptr).sys);
@@ -79,7 +79,8 @@ where
                 return Err(Error::Libyaml(libyaml::error::Error::emit_error(emitter)));
             }
             sys::yaml_emitter_set_unicode(emitter, true);
-            sys::yaml_emitter_set_width(emitter, -1);
+            sys::yaml_emitter_set_width(emitter, width);
+            sys::yaml_emitter_set_indent(emitter, indent);
             addr_of_mut!((*owned.ptr).write).write(Some(write));
             addr_of_mut!((*owned.ptr).write_error).write(None);
             sys::yaml_emitter_set_output(emitter, write_handler::<W>, owned.ptr.cast());

--- a/src/libyaml/error.rs
+++ b/src/libyaml/error.rs
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn emit_error_after_drop() {
         let err = {
-            let mut emitter = Emitter::new(Vec::<u8>::new()).unwrap();
+            let mut emitter = Emitter::new(Vec::<u8>::new(), -1, 2).unwrap();
             emitter.emit(Event::MappingEnd).unwrap_err()
         };
         if let EmitterError::Libyaml(inner) = err {

--- a/tests/test_serializer_builder.rs
+++ b/tests/test_serializer_builder.rs
@@ -1,0 +1,35 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Inner { value: u32 }
+#[derive(Serialize)]
+struct Outer { inner: Inner }
+
+#[test]
+fn custom_indent() {
+    let mut buf = Vec::new();
+    let mut ser = serde_yaml_bw::SerializerBuilder::new()
+        .indent(4)
+        .build(&mut buf)
+        .unwrap();
+    let outer = Outer { inner: Inner { value: 1 } };
+    outer.serialize(&mut ser).unwrap();
+    drop(ser);
+    assert_eq!(String::from_utf8(buf).unwrap(), "inner:\n    value: 1\n");
+}
+
+#[test]
+fn custom_width() {
+    #[derive(Serialize)]
+    struct Data { text: String }
+    let mut buf = Vec::new();
+    let mut ser = serde_yaml_bw::SerializerBuilder::new()
+        .width(10)
+        .build(&mut buf)
+        .unwrap();
+    let data = Data { text: "a b c d e f g h i j k l m n o p".to_string() };
+    data.serialize(&mut ser).unwrap();
+    drop(ser);
+    let output = String::from_utf8(buf).unwrap();
+    assert!(output.contains("\n  d e f"));
+}


### PR DESCRIPTION
## Summary
- add `SerializerBuilder` with `width`, `indent` and scalar style options
- pass width and indent to libyaml emitter
- construct `Serializer` using the builder for backward compatibility
- export new builder and test custom indent/width behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ff2b3f100832cbfaf62d20cff47a7