### PR TITLE
Add runtime yaml! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,17 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
+ "serde_yaml_bw_macros",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_bw_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 unsafe-libyaml = "0.2.11"
 base64 = ">=0.21, <=0.22"
 regex = "1.11.1"
+serde_yaml_bw_macros = { path = "serde_yaml_bw_macros" }
 
 [dev-dependencies]
 anyhow = "1.0" # All range tested

--- a/README.md
+++ b/README.md
@@ -196,6 +196,21 @@ fn read_records() -> std::io::Result<()> {
 }
 ```
 
+### `yaml!` macro
+
+The `yaml!` procedural macro builds a [`Value`](https://docs.rs/serde_yaml_bw/latest/serde_yaml_bw/value/enum.Value.html)
+from a string literal at runtime. Invalid YAML causes a panic at the call site.
+
+```rust
+use serde_yaml_bw::{yaml, Value};
+
+let value: Value = yaml!("foo: 42");
+assert_eq!(value["foo"], Value::from(42));
+
+// This panics at runtime
+// let _ = yaml!("{invalid yaml}");
+```
+
 [`DeserializerOptions`](https://docs.rs/serde_yaml_bw/latest/serde_yaml_bw/struct.DeserializerOptions.html)
 can be adjusted to control recursion or alias expansion limits. The formatting of emitted YAML can be configured using
 [`SerializerBuilder`](https://docs.rs/serde_yaml_bw/latest/serde_yaml_bw/struct.SerializerBuilder.html) that is

--- a/serde_yaml_bw_macros/Cargo.toml
+++ b/serde_yaml_bw_macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "serde_yaml_bw_macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["derive"] }

--- a/serde_yaml_bw_macros/src/lib.rs
+++ b/serde_yaml_bw_macros/src/lib.rs
@@ -1,0 +1,13 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, LitStr};
+
+#[proc_macro]
+pub fn yaml(input: TokenStream) -> TokenStream {
+    let lit = parse_macro_input!(input as LitStr);
+    let tokens = quote! {
+        serde_yaml_bw::from_str::<serde_yaml_bw::Value>(#lit)
+            .expect("failed to parse YAML at runtime")
+    };
+    tokens.into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,9 @@ pub use crate::value::{from_value, to_value, Number, Sequence, Value};
 #[doc(inline)]
 pub use crate::mapping::Mapping;
 
+#[doc(inline)]
+pub use serde_yaml_bw_macros::yaml;
+
 mod de;
 mod error;
 mod libyaml;

--- a/tests/test_yaml_macro.rs
+++ b/tests/test_yaml_macro.rs
@@ -1,0 +1,13 @@
+use serde_yaml_bw::{yaml, Value};
+
+#[test]
+fn yaml_macro_parses_value() {
+    let v: Value = yaml!("a: 1");
+    assert_eq!(v["a"], Value::from(1));
+}
+
+#[test]
+#[should_panic]
+fn yaml_macro_panics_on_invalid_yaml() {
+    let _v: Value = yaml!(":");
+}


### PR DESCRIPTION
## Summary
- introduce new `serde_yaml_bw_macros` crate exposing `yaml!` proc macro
- re-export `yaml!` from `serde_yaml_bw`
- document macro usage
- test macro behaviour

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6880c686dfa8832c950a2e56d8be5436