### PR TITLE
Add composite key example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,46 @@ let yaml = r#"
         v: 3.5
       "#;
 
-  let robot_moves: Vec<Move> = serde_yaml_bw::from_str(yaml).unwrap();
+let robot_moves: Vec<Move> = serde_yaml_bw::from_str(yaml).unwrap();
+}
+```
+
+### Composite keys
+
+Complex YAML keys are fully supported. Here each `Point` serves as a key mapping
+into another `Point`.
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct Point { x: i32, y: i32 }
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Transform {
+    map: HashMap<Point, Point>,
+}
+
+fn main() {
+    let yaml = r#"\
+map:
+  ? x: 1
+    y: 2
+  : x: 3
+    y: 4
+  ? x: 5
+    y: 6
+  : x: 7
+    y: 8
+"#;
+
+    // Deserialize YAML into the Transform struct.
+    let transform: Transform = serde_yaml_bw::from_str(yaml).unwrap();
+
+    // Serializing will produce the same mapping (order may vary).
+    let serialized = serde_yaml_bw::to_string(&transform).unwrap();
+    println!("{}", serialized);
 }
 ```
 

--- a/tests/test_composite_keys.rs
+++ b/tests/test_composite_keys.rs
@@ -1,0 +1,74 @@
+use indoc::indoc;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Transform {
+    map: HashMap<Point, Point>,
+}
+
+#[test]
+fn test_deserialize_transform() {
+    let yaml = indoc! {
+        "
+        map:
+          ? x: 1
+            y: 2
+          : x: 3
+            y: 4
+          ? x: 5
+            y: 6
+          : x: 7
+            y: 8
+        "
+    };
+
+    let mut map = HashMap::new();
+    map.insert(Point { x: 1, y: 2 }, Point { x: 3, y: 4 });
+    map.insert(Point { x: 5, y: 6 }, Point { x: 7, y: 8 });
+    let expected = Transform { map };
+    let actual: Transform = serde_yaml_bw::from_str(yaml).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn test_serialize_transform() {
+    let mut map = HashMap::new();
+    map.insert(Point { x: 1, y: 2 }, Point { x: 3, y: 4 });
+    map.insert(Point { x: 5, y: 6 }, Point { x: 7, y: 8 });
+    let transform = Transform { map };
+    let yaml = serde_yaml_bw::to_string(&transform).unwrap();
+    let expected_a = indoc! {
+        "
+        map:
+          ? x: 1
+            y: 2
+          : x: 3
+            y: 4
+          ? x: 5
+            y: 6
+          : x: 7
+            y: 8
+        "
+    };
+    let expected_b = indoc! {
+        "
+        map:
+          ? x: 5
+            y: 6
+          : x: 7
+            y: 8
+          ? x: 1
+            y: 2
+          : x: 3
+            y: 4
+        "
+    };
+    assert!(yaml == expected_a || yaml == expected_b);
+}


### PR DESCRIPTION
## Summary
- document support for composite YAML mapping keys
- add `tests/test_composite_keys.rs` to verify `Transform` with `HashMap<Point, Point>`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6883278cf5b0832cb904460125799544