### PR TITLE
Refactor tests to avoid Value

### DIFF
--- a/tests/test_block_scalars.rs
+++ b/tests/test_block_scalars.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use std::collections::BTreeMap;
 use indoc::indoc;
 use serde::Deserialize;
-use serde_yaml_bw::Value;
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Scalars {
@@ -55,7 +53,6 @@ fn test_block_scalars() {
     assert_eq!(expected, result);
 }
 
-
 #[test]
 fn test_block_scalars_2() {
     let yaml = indoc! {
@@ -81,11 +78,20 @@ fn test_block_scalars_2() {
           bar
         "
     };
-    let data: BTreeMap<String, Value> = serde_yaml_bw::from_str(yaml).unwrap();
-    assert_eq!(data.get("literal_clip").unwrap(), "foo\nbar\n");
-    assert_eq!(data.get("literal_strip").unwrap(), "foo\nbar");
-    assert_eq!(data.get("literal_keep").unwrap(), "foo\nbar\n\n");
-    assert_eq!(data.get("folded_clip").unwrap(), "foo bar\n");
-    assert_eq!(data.get("folded_strip").unwrap(), "foo bar");
-    assert_eq!(data.get("folded_keep").unwrap(), "foo bar\n");
+    #[derive(Debug, Deserialize)]
+    struct Scalars2 {
+        literal_clip: String,
+        literal_strip: String,
+        literal_keep: String,
+        folded_clip: String,
+        folded_strip: String,
+        folded_keep: String,
+    }
+    let data: Scalars2 = serde_yaml_bw::from_str(yaml).unwrap();
+    assert_eq!(data.literal_clip, "foo\nbar\n");
+    assert_eq!(data.literal_strip, "foo\nbar");
+    assert_eq!(data.literal_keep, "foo\nbar\n\n");
+    assert_eq!(data.folded_clip, "foo bar\n");
+    assert_eq!(data.folded_strip, "foo bar");
+    assert_eq!(data.folded_keep, "foo bar\n");
 }

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -72,7 +72,6 @@ where
     let deserialized: T = T::deserialize(Deserializer::from_str(yaml)).unwrap();
     assert_eq!(*expected, deserialized);
 
-    serde_yaml_bw::from_str::<serde_yaml_bw::Value>(yaml).unwrap();
     serde_yaml_bw::from_str::<serde::de::IgnoredAny>(yaml).unwrap();
 }
 
@@ -84,7 +83,6 @@ where
     let deserialized: T = seed.deserialize(Deserializer::from_str(yaml)).unwrap();
     assert_eq!(*expected, deserialized);
 
-    serde_yaml_bw::from_str::<serde_yaml_bw::Value>(yaml).unwrap();
     serde_yaml_bw::from_str::<serde::de::IgnoredAny>(yaml).unwrap();
 }
 
@@ -342,12 +340,18 @@ fn test_i128_big() {
     let yaml = indoc! {"
         -9223372036854775809
     "};
-    assert_eq!(expected, i128::deserialize(Deserializer::from_str(yaml)).unwrap());
+    assert_eq!(
+        expected,
+        i128::deserialize(Deserializer::from_str(yaml)).unwrap()
+    );
 
     let octal = indoc! {"
         -0o1000000000000000000001
     "};
-    assert_eq!(expected, i128::deserialize(Deserializer::from_str(octal)).unwrap());
+    assert_eq!(
+        expected,
+        i128::deserialize(Deserializer::from_str(octal)).unwrap()
+    );
 }
 
 #[test]
@@ -356,12 +360,18 @@ fn test_u128_big() {
     let yaml = indoc! {"
         18446744073709551616
     "};
-    assert_eq!(expected, u128::deserialize(Deserializer::from_str(yaml)).unwrap());
+    assert_eq!(
+        expected,
+        u128::deserialize(Deserializer::from_str(yaml)).unwrap()
+    );
 
     let octal = indoc! {"
         0o2000000000000000000000
     "};
-    assert_eq!(expected, u128::deserialize(Deserializer::from_str(octal)).unwrap());
+    assert_eq!(
+        expected,
+        u128::deserialize(Deserializer::from_str(octal)).unwrap()
+    );
 }
 
 #[test]
@@ -459,7 +469,10 @@ fn test_bomb() {
         expected: "string".to_owned(),
     };
 
-    assert_eq!(expected, Data::deserialize(Deserializer::from_str(yaml)).unwrap());
+    assert_eq!(
+        expected,
+        Data::deserialize(Deserializer::from_str(yaml)).unwrap()
+    );
 }
 
 #[test]
@@ -488,25 +501,20 @@ fn test_numbers() {
         (".NAN", ".nan"),
         ("0.1", "0.1"),
     ];
+    use serde_yaml_bw::Number;
     for &(yaml, expected) in &cases {
-        let value = serde_yaml_bw::from_str::<Value>(yaml).unwrap();
-        match value {
-            Value::Number(number, _) => assert_eq!(number.to_string(), expected),
-            _ => panic!("expected number. input={:?}, result={:?}", yaml, value),
-        }
+        let number = serde_yaml_bw::from_str::<Number>(yaml).unwrap();
+        assert_eq!(number.to_string(), expected);
     }
 
     // NOT numbers.
     let cases = [
-        "0127", "+0127", "-0127", "++.inf", "+-.inf", "++1", "+-1", "-+1", "--1", "+--1", "0x+1", "0x-1",
-        "-0x+1", "-0x-1", "++0x1", "+-0x1", "-+0x1", "--0x1",
+        "0127", "+0127", "-0127", "++.inf", "+-.inf", "++1", "+-1", "-+1", "--1", "+--1", "0x+1",
+        "0x-1", "-0x+1", "-0x-1", "++0x1", "+-0x1", "-+0x1", "--0x1",
     ];
     for yaml in &cases {
-        let value = serde_yaml_bw::from_str::<Value>(yaml).unwrap();
-        match value {
-            Value::String(string, _) => assert_eq!(string, *yaml),
-            _ => panic!("expected string. input={:?}, result={:?}", yaml, value),
-        }
+        let string = serde_yaml_bw::from_str::<String>(yaml).unwrap();
+        assert_eq!(string, *yaml);
     }
 }
 
@@ -781,10 +789,17 @@ fn test_enum_untagged() {
     #[derive(Deserialize, PartialEq, Debug)]
     #[serde(untagged)]
     pub enum UntaggedEnum {
-        A { r#match: bool },
-        AB { r#match: String },
-        B { #[serde(rename = "if")] r#match: bool },
-        C(String)
+        A {
+            r#match: bool,
+        },
+        AB {
+            r#match: String,
+        },
+        B {
+            #[serde(rename = "if")]
+            r#match: bool,
+        },
+        C(String),
     }
 
     // A
@@ -795,7 +810,9 @@ fn test_enum_untagged() {
     }
     // AB
     {
-        let expected = UntaggedEnum::AB { r#match: "T".to_owned() };
+        let expected = UntaggedEnum::AB {
+            r#match: "T".to_owned(),
+        };
         let deserialized: UntaggedEnum = serde_yaml_bw::from_str("match: T").unwrap();
         assert_eq!(expected, deserialized);
     }

--- a/tests/test_error_format.rs
+++ b/tests/test_error_format.rs
@@ -1,10 +1,14 @@
-use serde_yaml_bw::{from_str, Value};
+use serde::Deserialize;
+use serde_yaml_bw::from_str;
+
+#[derive(Debug, Deserialize)]
+struct Dummy;
 
 #[test]
 fn test_error_includes_location_in_formats() {
     // YAML starting with a literal block followed by invalid character to cause an error
     let yaml = ">\n@";
-    let err = from_str::<Value>(yaml).unwrap_err();
+    let err = from_str::<Dummy>(yaml).unwrap_err();
     let loc = err.location().expect("location not available");
     assert_eq!(loc.line(), 2);
     assert_eq!(loc.column(), 1);
@@ -12,8 +16,14 @@ fn test_error_includes_location_in_formats() {
     let display = format!("{}", err);
     let debug = format!("{:?}", err);
     let pos_display = format!("line {} column {}", loc.line(), loc.column());
-    assert!(display.contains(&pos_display), "Display output missing location: {display}");
+    assert!(
+        display.contains(&pos_display),
+        "Display output missing location: {display}"
+    );
 
     let pos_debug = format!("line: {}, column: {}", loc.line(), loc.column());
-    assert!(debug.contains(&pos_debug), "Debug output missing location: {debug}");
+    assert!(
+        debug.contains(&pos_debug),
+        "Debug output missing location: {debug}"
+    );
 }

--- a/tests/test_no_panic.rs
+++ b/tests/test_no_panic.rs
@@ -1,9 +1,16 @@
 use serde::Deserialize;
-use serde_yaml_bw::{Deserializer, Value};
+use serde_yaml_bw::Deserializer;
+
+#[derive(Debug, Deserialize)]
+struct Placeholder {
+    #[allow(dead_code)]
+    key: Option<String>,
+}
 
 #[test]
 fn null_key() {
-    let yaml: serde_json::Value = serde_json::Value::deserialize(Deserializer::from_str(r#"null: "key_value""#)).unwrap();
+    let yaml: serde_json::Value =
+        serde_json::Value::deserialize(Deserializer::from_str(r#"null: "key_value""#)).unwrap();
     let json_str = serde_json::to_string(&yaml).unwrap();
     assert_eq!("{\"null\":\"key_value\"}", json_str);
 }
@@ -13,7 +20,7 @@ fn test_yaml_malformed() {
     #[derive(Debug, Deserialize)]
     #[allow(dead_code)]
     struct TestStruct {
-        x: String
+        x: String,
     }
 
     let yaml_input = "\n    x {\n        ";
@@ -22,77 +29,95 @@ fn test_yaml_malformed() {
     println!("{result:?}");
 
     // Confirm parsing yields an error, and does not panic or succeed.
-    assert!(result.is_err(), "Parsing invalid YAML should fail with an error, not succeed.");
+    assert!(
+        result.is_err(),
+        "Parsing invalid YAML should fail with an error, not succeed."
+    );
 }
 
 #[test]
 fn test_lexer_errors() {
     let yaml_input = ">\n@ !";
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
 
     // The YAML input is invalid, so expect an Err, but no panic
-    assert!(result.is_err(), "Parsing invalid YAML should return an error, not panic.");
+    assert!(
+        result.is_err(),
+        "Parsing invalid YAML should return an error, not panic."
+    );
 }
 
 #[test]
 fn test_unmatched_brackets() {
     let yaml_input = "{key: [value1, value2";
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
-    assert!(result.is_err(), "Unmatched brackets should yield an error without panic.");
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
+    assert!(
+        result.is_err(),
+        "Unmatched brackets should yield an error without panic."
+    );
 }
 
 #[test]
 fn test_invalid_escape_sequence() {
     let yaml_input = r#"key: "Invalid\xEscape""#;
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
-    assert!(result.is_err(), "Invalid escape sequences should yield an error without panic.");
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
+    assert!(
+        result.is_err(),
+        "Invalid escape sequences should yield an error without panic."
+    );
 }
 
 #[test]
 fn test_invalid_boolean_tagged() {
     let yaml_input = "key: !!bool truue";
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
-    assert!(result.is_err(), "Tagged invalid boolean should yield an error without panic.");
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
+    assert!(
+        result.is_err(),
+        "Tagged invalid boolean should yield an error without panic."
+    );
 }
 
 #[test]
 fn test_deeply_nested_structures() {
     let yaml_input = format!("{}{}", "[".repeat(10_000), "]".repeat(10_000));
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(&yaml_input);
-    assert!(result.is_err(), "Deeply nested structures should gracefully return an error.");
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(&yaml_input);
+    assert!(
+        result.is_err(),
+        "Deeply nested structures should gracefully return an error."
+    );
 }
 
 #[test]
 fn test_incomplete_quoting() {
     let yaml_input = "key: \"unterminated string";
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
     assert!(result.is_err(), "Incomplete quoting should yield an error.");
 }
 
 #[test]
 fn test_invalid_anchor_reference() {
     let yaml_input = "key: *undefined_anchor";
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
     assert!(result.is_err(), "Undefined anchors should yield an error.");
 }
 
 #[test]
 fn test_cyclic_references() {
     let yaml_input = "&a [ *a ]";
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
     assert!(result.is_err(), "Cyclic references should yield an error.");
 }
 
 #[test]
 fn test_unexpected_eof() {
     let yaml_input = "{key: value";
-    let result: Result<serde_yaml_bw::Value, _> = serde_yaml_bw::from_str(yaml_input);
+    let result: Result<Placeholder, _> = serde_yaml_bw::from_str(yaml_input);
     assert!(result.is_err(), "Unexpected EOF should yield an error.");
 }
 
 #[test]
 fn test_empty_input() {
-    assert_eq!(serde_yaml_bw::from_str::<Value>("").unwrap(), Value::Null(None));
+    assert_eq!(serde_yaml_bw::from_str::<Option<u8>>("").unwrap(), None);
 }
 
 #[test]

--- a/tests/test_recursion_limit.rs
+++ b/tests/test_recursion_limit.rs
@@ -1,10 +1,13 @@
-use serde_yaml_bw::Value;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Dummy;
 
 #[test]
 fn test_recursion_limit_exceeded() {
     let depth = 129;
     let yaml = "[".repeat(depth) + &"]".repeat(depth);
-    let err = serde_yaml_bw::from_str::<Value>(&yaml).unwrap_err();
+    let err = serde_yaml_bw::from_str::<Dummy>(&yaml).unwrap_err();
     assert!(
         err.to_string().starts_with("recursion limit exceeded"),
         "unexpected error: {}",

--- a/tests/test_writer_reader.rs
+++ b/tests/test_writer_reader.rs
@@ -38,14 +38,11 @@ fn test_large_reader_input() {
         i += 1;
     }
 
+    #[derive(Debug, Deserialize)]
+    struct Dynamic(#[allow(dead_code)] HashMap<String, String>);
     let reader = std::io::Cursor::new(yaml.as_bytes());
-    let value: serde_yaml_bw::Value = serde_yaml_bw::from_reader(reader).unwrap();
-
-    if let serde_yaml_bw::Value::Mapping(map) = value {
-        assert!(map.len() > 0);
-    } else {
-        panic!("Expected mapping");
-    }
+    let value: Dynamic = serde_yaml_bw::from_reader(reader).unwrap();
+    assert!(!value.0.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace `Value` usage with custom structs where practical
- update block scalar parsing to typed structs
- adjust writer and recursion tests to use minimal structs
- clean up panic tests to deserialize into a placeholder
- remove leftover Value parsing from helpers
- use `Number` for numeric deserialization tests

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688711fec734832c8c4ab718e17d5c29