### PR TITLE
Derive Debug for deserialization options and duplicate key errors

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -31,7 +31,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 const DEFAULT_RECURSION_LIMIT: u8 = 128;
 
 /// Configuration options for YAML deserialization.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DeserializerOptions {
     /// Maximum depth allowed during deserialization before reporting
     /// [`RecursionLimitExceeded`]. A value of 0 disables the check.

--- a/src/duplicate_key.rs
+++ b/src/duplicate_key.rs
@@ -3,7 +3,7 @@ use crate::value::Value;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum DuplicateKeyKind {
     Null,
     Bool(bool),
@@ -12,6 +12,7 @@ pub(crate) enum DuplicateKeyKind {
     Other,
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct DuplicateKeyError {
     pub(crate) kind: DuplicateKeyKind,
 }


### PR DESCRIPTION
## Summary
- derive `Clone` and `Debug` for `DeserializerOptions`
- derive `Clone` and `Debug` for duplicate key errors

## Testing
- `cargo check`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6896514dfa44832c81a4e82b64272519