### PR TITLE
Document safety for libyaml helpers

### DIFF
--- a/src/libyaml/cstr.rs
+++ b/src/libyaml/cstr.rs
@@ -40,6 +40,10 @@ impl<'a> CStr<'a> {
         unsafe { Self::from_ptr(ptr) }
     }
 
+    /// # Safety
+    ///
+    /// `ptr` must be a non-null, valid pointer to a null-terminated sequence of
+    /// bytes that live for the lifetime `'a`.
     pub unsafe fn from_ptr(ptr: NonNull<i8>) -> Self {
         CStr {
             ptr: ptr.cast(),

--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -212,6 +212,10 @@ where
     }
 }
 
+/// # Safety
+///
+/// `data` must be a pointer to `EmitterPinned<W>` previously registered with
+/// libyaml. `buffer` must be valid for reads of `size` bytes.
 unsafe fn write_handler<W>(data: *mut c_void, buffer: *mut u8, size: u64) -> i32
 where
     W: io::Write,

--- a/src/libyaml/error.rs
+++ b/src/libyaml/error.rs
@@ -14,6 +14,9 @@ pub(crate) struct Error {
     context_mark: Mark,
 }
 
+/// # Safety
+///
+/// `problem` must point to a valid null-terminated string provided by libyaml.
 unsafe fn define_string(problem: NonNull<i8>) -> Box<[u8]> {
     const EMPTY_Z: [u8; 1] = [0];
     Box::from(unsafe { CStr::from_ptr(problem) }
@@ -21,6 +24,10 @@ unsafe fn define_string(problem: NonNull<i8>) -> Box<[u8]> {
 }
 
 impl Error {
+    /// # Safety
+    ///
+    /// `parser` must be a valid, initialized pointer to a libyaml parser
+    /// structure.
     pub unsafe fn parse_error(parser: *const sys::yaml_parser_t) -> Self {
         Error {
             kind: unsafe { (&*parser).error },
@@ -42,6 +49,10 @@ impl Error {
         }
     }
 
+    /// # Safety
+    ///
+    /// `emitter` must be a valid, initialized pointer to a libyaml emitter
+    /// structure.
     pub unsafe fn emit_error(emitter: *const sys::yaml_emitter_t) -> Self {
         Error {
             kind: unsafe { (&*emitter).error },

--- a/src/libyaml/parser.rs
+++ b/src/libyaml/parser.rs
@@ -92,6 +92,11 @@ impl<'input> Parser<'input> {
     where
         R: Read + 'input,
     {
+        /// # Safety
+        ///
+        /// `data` must be a pointer to `ParserPinned`. `buffer` must be valid for
+        /// writes of `size` bytes and `size_read` must be a valid pointer to store
+        /// the number of bytes read.
         unsafe fn read_handler(
             data: *mut std::os::raw::c_void,
             buffer: *mut u8,
@@ -162,6 +167,11 @@ impl<'input> Parser<'input> {
     }
 }
 
+/// # Safety
+///
+/// `sys` must point to a valid libyaml event and any pointers contained within
+/// it must remain valid for the duration of this call. `input` must reference
+/// the original byte slice from which the event was produced.
 unsafe fn convert_event<'input>(
     sys: &sys::yaml_event_t,
     input: &Option<Cow<'input, [u8]>>,
@@ -215,6 +225,10 @@ unsafe fn convert_event<'input>(
     }
 }
 
+/// # Safety
+///
+/// If `anchor` is non-null, it must point to a null-terminated UTF-8 string
+/// that remains valid for the duration of the call.
 unsafe fn optional_anchor(anchor: *const u8) -> std::result::Result<Option<Anchor>, CStrError> {
     let ptr = match NonNull::new(anchor as *mut i8) {
         Some(p) => p,
@@ -224,6 +238,10 @@ unsafe fn optional_anchor(anchor: *const u8) -> std::result::Result<Option<Ancho
     Ok(Some(Anchor(Box::from(cstr.to_bytes()?))))
 }
 
+/// # Safety
+///
+/// If `tag` is non-null, it must point to a null-terminated UTF-8 string that
+/// remains valid for the duration of the call.
 unsafe fn optional_tag(tag: *const u8) -> std::result::Result<Option<Tag>, CStrError> {
     let ptr = match NonNull::new(tag as *mut i8) {
         Some(p) => p,

--- a/src/libyaml/util.rs
+++ b/src/libyaml/util.rs
@@ -17,6 +17,11 @@ impl<T> Owned<T> {
         }
     }
 
+    /// # Safety
+    ///
+    /// The `definitely_init` pointer must reference a value that has been fully
+    /// initialized. Passing a pointer to uninitialized data results in
+    /// undefined behavior.
     pub unsafe fn assume_init(definitely_init: Owned<MaybeUninit<T>, T>) -> Owned<T> {
         let ptr = definitely_init.ptr;
         mem::forget(definitely_init);


### PR DESCRIPTION
## Summary
- document safety requirements for `Owned::assume_init`
- clarify pointer validity for `optional_anchor` and `optional_tag`
- add missing safety notes to libyaml's remaining unsafe helpers

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689651c413f8832cbe7bd8cbce64ad5b