### PR TITLE
Handle UTF-8 errors in display_lossy

### DIFF
--- a/src/libyaml/cstr.rs
+++ b/src/libyaml/cstr.rs
@@ -32,7 +32,6 @@ unsafe impl Send for CStr<'static> {}
 unsafe impl Sync for CStr<'static> {}
 
 impl<'a> CStr<'a> {
-    
     #[cfg(test)]
     pub fn from_bytes_with_nul(bytes: &'static [u8]) -> Self {
         assert_eq!(bytes.last(), Some(&b'\0'));
@@ -72,8 +71,8 @@ impl<'a> CStr<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::thread;
     use std::ptr::NonNull;
+    use std::thread;
 
     #[test]
     fn send_sync_static() {
@@ -129,7 +128,10 @@ fn display_lossy(mut bytes: &[u8], formatter: &mut fmt::Formatter) -> fmt::Resul
                 let valid_up_to = utf8_error.valid_up_to();
 
                 // The substring `[..valid_up_to]` is guaranteed valid UTF-8.
-                formatter.write_str(str::from_utf8(&bytes[..valid_up_to]).unwrap())?;
+                match str::from_utf8(&bytes[..valid_up_to]) {
+                    Ok(valid) => formatter.write_str(valid)?,
+                    Err(_) => return Err(fmt::Error),
+                }
                 formatter.write_char(char::REPLACEMENT_CHARACTER)?;
 
                 if let Some(error_len) = utf8_error.error_len() {
@@ -145,7 +147,7 @@ fn display_lossy(mut bytes: &[u8], formatter: &mut fmt::Formatter) -> fmt::Resul
 
 pub(crate) fn debug_lossy(mut bytes: &[u8], formatter: &mut fmt::Formatter) -> fmt::Result {
     const EMPTY: &str = "";
-    
+
     formatter.write_char('"')?;
 
     while !bytes.is_empty() {
@@ -158,7 +160,6 @@ pub(crate) fn debug_lossy(mut bytes: &[u8], formatter: &mut fmt::Formatter) -> f
                 str::from_utf8(&bytes[..valid_up_to]).unwrap_or(EMPTY)
             }
         };
-
 
         let mut written = 0;
         for (i, ch) in valid.char_indices() {


### PR DESCRIPTION
## Summary
- avoid panic in `display_lossy` by matching on `str::from_utf8`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689651d5fd6c832c81d0fb0b7d32852b