### PR TITLE
Return error for alias without anchor

### DIFF
--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -126,8 +126,7 @@ fn test_invalid_anchor_reference_message() {
     match result {
         Ok(_) => panic!("Expected error for invalid anchor"),
         Err(e) => {
-            let msg = e.to_string();
-            assert!(msg.contains("invalid_anchor"), "Unexpected error: {}", msg);
+            assert_eq!("unknown anchor [invalid_anchor]", e.to_string());
         }
     }
 }


### PR DESCRIPTION
## Summary
- return `UnknownAnchor` error when alias events have no anchor instead of inserting a placeholder
- adjust parser's optional anchor/tag helpers to surface tag errors directly
- update invalid anchor test to expect the specific `UnknownAnchor` message

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689651f5bea4832ca7c2a804d2c3db8d