### PR TITLE
docs: sync html_root_url with crate version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/serde_yaml_bw/2.1.0")]
+#![doc(html_root_url = "https://docs.rs/serde_yaml_bw/2.1.3")]
 #![deny(missing_docs, unsafe_op_in_unsafe_fn)]
 // Suppressed clippy_pedantic lints
 #![allow(

--- a/tests/html_root_url.rs
+++ b/tests/html_root_url.rs
@@ -1,0 +1,17 @@
+#[test]
+fn html_root_url_matches_package_version() {
+    let lib_rs = include_str!("../src/lib.rs");
+    let actual = lib_rs
+        .lines()
+        .find(|line| line.contains("html_root_url"))
+        .expect("html_root_url attribute missing");
+    let expected = format!(
+        "#![doc(html_root_url = \"https://docs.rs/serde_yaml_bw/{}\")]",
+        env!("CARGO_PKG_VERSION"),
+    );
+    assert_eq!(
+        actual,
+        expected,
+        "html_root_url attribute is out of sync with package version",
+    );
+}


### PR DESCRIPTION
## Summary
- update docs.rs html_root_url to current crate version
- add regression test to ensure html_root_url matches crate version

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f31e0c98832ca38d2f3bcf4c20a6