### PR TITLE
Use write! macro for UnknownAnchor error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -245,8 +245,9 @@ impl ErrorImpl {
             ),
             ErrorImpl::RecursionLimitExceeded(_mark) => f.write_str("recursion limit exceeded"),
             ErrorImpl::RepetitionLimitExceeded => f.write_str("repetition limit exceeded"),
-            ErrorImpl::UnknownAnchor(_mark, alias) => f.write_str(
-                &format!("unknown anchor [{}]", &sanitize(alias))),
+            ErrorImpl::UnknownAnchor(_mark, alias) => {
+                write!(f, "unknown anchor [{}]", sanitize(alias))
+            }
             ErrorImpl::ScalarInMerge => {
                 f.write_str("expected a mapping or list of mappings for merging, but found scalar")
             }


### PR DESCRIPTION
## Summary
- use `write!` macro for formatting the `UnknownAnchor` error message

## Testing
- `cargo check`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f26b68bc832c8da82010719732e6