### PR TITLE
Document safety invariants around libyaml FFI

### DIFF
--- a/src/libyaml/util.rs
+++ b/src/libyaml/util.rs
@@ -12,11 +12,14 @@ impl<T> Owned<T> {
     pub fn new_uninit() -> Owned<MaybeUninit<T>, T> {
         let boxed = Box::<T>::new_uninit();
         Owned {
+            // SAFETY: `Box::into_raw` never returns null and we immediately wrap it
+            // in `NonNull` to preserve that invariant.
             ptr: unsafe { NonNull::new_unchecked(Box::into_raw(boxed)) },
             marker: PhantomData,
         }
     }
 
+    // SAFETY: `definitely_init` must contain a fully initialized `T`.
     pub unsafe fn assume_init(definitely_init: Owned<MaybeUninit<T>, T>) -> Owned<T> {
         let ptr = definitely_init.ptr;
         mem::forget(definitely_init);
@@ -36,12 +39,16 @@ impl<T, Init> Deref for Owned<T, Init> {
     type Target = InitPtr<Init>;
 
     fn deref(&self) -> &Self::Target {
+        // SAFETY: `self.ptr` is always valid and properly aligned; we only cast the
+        // address to `InitPtr` for ergonomic field access.
         unsafe { &*addr_of!(self.ptr).cast::<InitPtr<Init>>() }
     }
 }
 
 impl<T, Init> Drop for Owned<T, Init> {
     fn drop(&mut self) {
+        // SAFETY: `self.ptr` was allocated via `Box` and has unique ownership,
+        // so reconstructing it here to drop is sound.
         let _ = unsafe { Box::from_raw(self.ptr.as_ptr()) };
     }
 }


### PR DESCRIPTION
## Summary
- Annotate libyaml error helpers with detailed SAFETY comments
- Explain unsafety in parser and emitter FFI interactions
- Clarify invariants for C string and Owned utilities

## Testing
- `cargo check` *(fails: command not found)*
- `cargo test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6f2439018832cb1e55cddd035037f