### PR TITLE
Use `?` in from_str examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 //!             x: 1.0
 //!             y: 2.0
 //!     ";
-//!     let values: Vec<Enum> = serde_yaml_bw::from_str(yaml).unwrap();
+//!     let values: Vec<Enum> = serde_yaml_bw::from_str(yaml)?;
 //!     assert_eq!(values[0], Enum::Newtype(1));
 //!     assert_eq!(values[1], Enum::Tuple(0, 0, 0));
 //!     assert_eq!(values[2], Enum::Struct { x: 1.0, y: 2.0 });
@@ -100,7 +100,7 @@
 //!             x: 1.0
 //!             y: 2.0
 //!     ";
-//!     let values: Vec<Enum> = serde_yaml_bw::from_str(yaml).unwrap();
+//!     let values: Vec<Enum> = serde_yaml_bw::from_str(yaml)?;
 //!     assert_eq!(values[0], Enum::Tuple(0, 0, 0));
 //!     assert_eq!(values[1], Enum::Struct { x: 1.0, y: 2.0 });
 //!
@@ -108,7 +108,7 @@
 //!     let yaml = "
 //!         - Unit
 //!     ";
-//!     let values: Vec<Enum> = serde_yaml_bw::from_str(yaml).unwrap();
+//!     let values: Vec<Enum> = serde_yaml_bw::from_str(yaml)?;
 //!     assert_eq!(values[0], Enum::Unit);
 //!
 //!     Ok(())


### PR DESCRIPTION
## Summary
- replace `unwrap` with `?` in enum deserialization doc example to propagate errors

## Testing
- `cargo check`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f23a2f5c832ca8da879aeab9bd6f