### PR TITLE
docs: drop Deserializer import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ handling:
 
 ```rust
 use serde::Deserialize;
-use serde_yaml_bw::Deserializer;
 
 // Define the structure representing your YAML data.
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary
- remove unnecessary `Deserializer` import from initial README example

## Testing
- `cargo check`
- `cargo build`
- `cargo test`
- `cargo run --example readme_usage` *(example fails to parse, demonstrating error handling)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f328219c832cb8ac880f9b71c746