### PR TITLE
Support YAML anchors during serialization

### DIFF
--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -44,6 +44,7 @@ pub(crate) enum Event<'a> {
 
 #[derive(Debug)]
 pub(crate) struct Scalar<'a> {
+    pub anchor: Option<String>,
     pub tag: Option<String>,
     pub value: &'a str,
     pub style: ScalarStyle,
@@ -59,11 +60,13 @@ pub enum ScalarStyle {
 
 #[derive(Debug)]
 pub(crate) struct Sequence {
+    pub anchor: Option<String>,
     pub tag: Option<String>,
 }
 
 #[derive(Debug)]
 pub(crate) struct Mapping {
+    pub anchor: Option<String>,
     pub tag: Option<String>,
 }
 
@@ -121,7 +124,10 @@ where
                     sys::yaml_document_end_event_initialize(sys_event, implicit)
                 }
                 Event::Scalar(mut scalar) => {
-                    let anchor = ptr::null();
+                    let anchor = scalar.anchor.as_mut().map_or_else(ptr::null, |a| {
+                        a.push('\0');
+                        a.as_ptr()
+                    });
                     let tag = scalar.tag.as_mut().map_or_else(ptr::null, |tag| {
                         tag.push('\0');
                         tag.as_ptr()
@@ -148,7 +154,10 @@ where
                     )
                 }
                 Event::SequenceStart(mut sequence) => {
-                    let anchor = ptr::null();
+                    let anchor = sequence.anchor.as_mut().map_or_else(ptr::null, |a| {
+                        a.push('\0');
+                        a.as_ptr()
+                    });
                     let tag = sequence.tag.as_mut().map_or_else(ptr::null, |tag| {
                         tag.push('\0');
                         tag.as_ptr()
@@ -161,7 +170,10 @@ where
                 }
                 Event::SequenceEnd => sys::yaml_sequence_end_event_initialize(sys_event),
                 Event::MappingStart(mut mapping) => {
-                    let anchor = ptr::null();
+                    let anchor = mapping.anchor.as_mut().map_or_else(ptr::null, |a| {
+                        a.push('\0');
+                        a.as_ptr()
+                    });
                     let tag = mapping.tag.as_mut().map_or_else(ptr::null, |tag| {
                         tag.push('\0');
                         tag.as_ptr()

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -806,8 +806,12 @@ impl<'a> VacantEntry<'a> {
 
 impl Serialize for Mapping {
     #[inline]
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S>(&self, mut serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer + crate::ser::Anchorable<Error = S::Error>,
+    {
         use serde::ser::SerializeMap;
+        serializer.set_anchor(self.anchor.as_deref())?;
         let mut map_serializer = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
             map_serializer.serialize_entry(k, v)?;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -121,10 +121,11 @@ impl std::hash::Hash for Sequence {
 }
 
 impl serde::Serialize for Sequence {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, mut serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde::Serializer + crate::ser::Anchorable<Error = S::Error>,
     {
+        serializer.set_anchor(self.anchor.as_deref())?;
         self.elements.serialize(serializer)
     }
 }

--- a/tests/test_anchor_serialization.rs
+++ b/tests/test_anchor_serialization.rs
@@ -1,0 +1,25 @@
+use serde_yaml_bw::{Number, Value, Mapping};
+use serde_yaml_bw::value::Sequence;
+
+#[test]
+fn serialize_scalar_with_anchor() {
+    let value = Value::Number(Number::from(1), Some("id".to_string()));
+    let yaml = serde_yaml_bw::to_string(&value).unwrap();
+    assert_eq!(yaml, "&id 1\n");
+}
+
+#[test]
+fn serialize_sequence_with_anchor() {
+    let seq = Sequence { anchor: Some("s".to_string()), elements: vec![Value::Bool(true, None)] };
+    let yaml = serde_yaml_bw::to_string(&Value::Sequence(seq)).unwrap();
+    assert_eq!(yaml, "&s\n- true\n");
+}
+
+#[test]
+fn serialize_mapping_with_anchor() {
+    let mut map = Mapping::new();
+    map.anchor = Some("m".to_string());
+    map.insert(Value::String("k".into(), None), Value::Bool(false, None));
+    let yaml = serde_yaml_bw::to_string(&Value::Mapping(map)).unwrap();
+    assert_eq!(yaml, "&m\nk: false\n");
+}


### PR DESCRIPTION
## Summary
- allow serializer to emit anchors
- propagate anchors from `Value`, `Sequence`, and `Mapping`
- test serializing scalar, sequence, and mapping anchors

## Testing
- `cargo build` *(fails: command not found)*
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb23660680832c983f5969acd52b97