### PR TITLE
Support YAML anchor serialization for Value

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -18,6 +18,7 @@ use std::num;
 use std::str;
 
 pub(crate) const ALIAS_NEWTYPE: &str = "$serde_yaml::alias";
+pub(crate) const ANCHOR_NEWTYPE: &str = "$serde_yaml::anchor";
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -530,6 +531,8 @@ where
     {
         if name == ALIAS_NEWTYPE {
             value.serialize(AliasHelper { ser: &mut self })
+        } else if name == ANCHOR_NEWTYPE {
+            value.serialize(AnchorHelper { ser: &mut self })
         } else {
             value.serialize(self)
         }
@@ -818,6 +821,437 @@ where
     fn end(self) -> Result<()> {
         self.emit_mapping_end()?;
         self.emit_mapping_end()
+    }
+}
+
+struct AnchorHelper<'a, W>
+where
+    W: io::Write,
+{
+    ser: &'a mut Serializer<W>,
+}
+
+struct AnchorSeq<'a, W>
+where
+    W: io::Write,
+{
+    ser: &'a mut Serializer<W>,
+    state: AnchorState,
+}
+
+enum AnchorState {
+    Anchor,
+    Value,
+    Done,
+}
+
+struct AnchorName<'a, W>
+where
+    W: io::Write,
+{
+    ser: &'a mut Serializer<W>,
+}
+
+#[inline]
+fn anchor_must_be_string<T>() -> Result<T> {
+    Err(ser::Error::custom("anchor must be a string"))
+}
+
+impl<'a, W> ser::Serializer for AnchorHelper<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = AnchorSeq<'a, W>;
+    type SerializeTuple = AnchorSeq<'a, W>;
+    type SerializeTupleStruct = AnchorSeq<'a, W>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        if len != Some(2) {
+            return Err(ser::Error::custom("anchor requires tuple of (name, value)"));
+        }
+        Ok(AnchorSeq {
+            ser: self.ser,
+            state: AnchorState::Anchor,
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        if len != 2 {
+            return Err(ser::Error::custom("anchor requires tuple of (name, value)"));
+        }
+        Ok(AnchorSeq {
+            ser: self.ser,
+            state: AnchorState::Anchor,
+        })
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        if len != 2 {
+            return Err(ser::Error::custom("anchor requires tuple of (name, value)"));
+        }
+        Ok(AnchorSeq {
+            ser: self.ser,
+            state: AnchorState::Anchor,
+        })
+    }
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+    }
+}
+
+impl<'a, W> ser::SerializeSeq for AnchorSeq<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, elem: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match self.state {
+            AnchorState::Anchor => {
+                elem.serialize(AnchorName { ser: self.ser })?;
+                self.state = AnchorState::Value;
+                Ok(())
+            }
+            AnchorState::Value => {
+                elem.serialize(&mut *self.ser)?;
+                self.state = AnchorState::Done;
+                Ok(())
+            }
+            AnchorState::Done => Err(ser::Error::custom("anchor accepts only two elements")),
+        }
+    }
+
+    fn end(self) -> Result<(), Error> {
+        if matches!(self.state, AnchorState::Value | AnchorState::Anchor) {
+            Err(ser::Error::custom("anchor requires tuple of (name, value)"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'a, W> ser::SerializeTuple for AnchorSeq<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, elem: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, elem)
+    }
+
+    fn end(self) -> Result<(), Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl<'a, W> ser::SerializeTupleStruct for AnchorSeq<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, v: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, v)
+    }
+
+    fn end(self) -> Result<(), Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl<'a, W> ser::Serializer for AnchorName<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        self.ser.pending_anchor = Some(value.to_owned());
+        Ok(())
+    }
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        anchor_must_be_string()
+    }
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        anchor_must_be_string()
+    }
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        anchor_must_be_string()
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        anchor_must_be_string()
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        anchor_must_be_string()
     }
 }
 

--- a/tests/test_value_alias.rs
+++ b/tests/test_value_alias.rs
@@ -6,3 +6,38 @@ fn test_alias_serialization() {
     let yaml = serde_yaml_bw::to_string(&value).unwrap();
     assert_eq!(yaml, "*anchor\n");
 }
+
+#[test]
+fn test_alias_in_sequence_resolves() {
+    use serde_yaml_bw::value::Sequence;
+
+    let value = Value::Sequence(Sequence {
+        anchor: None,
+        elements: vec![
+            Value::Number(1.into(), Some("id".to_string())),
+            Value::Alias("id".to_string()),
+        ],
+    });
+
+    let yaml = serde_yaml_bw::to_string(&value).unwrap();
+    assert_eq!(yaml, "- &id 1\n- *id\n");
+}
+
+#[test]
+fn test_alias_in_mapping_branch() {
+    use serde_yaml_bw::Mapping;
+
+    let mut mapping = Mapping::new();
+    mapping.insert(
+        Value::String("a".to_string(), None),
+        Value::String("foo".to_string(), Some("id".to_string())),
+    );
+    mapping.insert(
+        Value::String("b".to_string(), None),
+        Value::Alias("id".to_string()),
+    );
+
+    let value = Value::Mapping(mapping);
+    let yaml = serde_yaml_bw::to_string(&value).unwrap();
+    assert_eq!(yaml, "a: &id foo\nb: *id\n");
+}


### PR DESCRIPTION
## Summary
- add anchor-aware serialization via `$serde_yaml::anchor`
- support anchors in `Value` serialization for scalars, sequences, and mappings
- test alias handling in sequences and mappings

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e57d0974832cb37ad677aabc8df7