### PR TITLE
Document anchors and expose apply_merge

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/serde_yaml_bw/2.1.3")]
+#![doc(html_root_url = "https://docs.rs/serde_yaml_bw/2.2.0")]
 #![deny(missing_docs, unsafe_op_in_unsafe_fn)]
 // Suppressed clippy_pedantic lints
 #![allow(

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -738,7 +738,7 @@ impl Value {
     /// assert_eq!(value["tasks"]["start"]["command"], "webpack");
     /// assert_eq!(value["tasks"]["start"]["args"], "start");
     /// ```
-    pub(crate) fn apply_merge(&mut self) -> Result<(), Error> {
+    pub fn apply_merge(&mut self) -> Result<(), Error> {
         use std::collections::HashSet;
         let mut stack = Vec::new();
         let mut visited = HashSet::new();


### PR DESCRIPTION
## Summary
- document anchors, aliases, and preserving them in README
- expose `Value::apply_merge` publicly
- sync `html_root_url` with crate version

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c442064c48832caa9a099f53a67fdf