### PR TITLE
Add constructors for anchored sequences and mappings

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -68,6 +68,16 @@ impl Mapping {
         }
     }
 
+    /// Creates an empty YAML map with the given anchor.
+    #[inline]
+    pub fn with_anchor(anchor: impl Into<String>) -> Self {
+        Mapping {
+            anchor: Some(anchor.into()),
+            map: IndexMap::new(),
+            id: crate::value::next_id(),
+        }
+    }
+
     /// Reserves capacity for at least `additional` more elements to be inserted
     /// into the map. The map may reserve more space to avoid frequent
     /// allocations.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -198,6 +198,15 @@ impl Sequence {
         }
     }
 
+    /// Creates an empty YAML sequence with the given anchor.
+    #[inline]
+    pub fn with_anchor(anchor: impl Into<String>) -> Self {
+        Sequence {
+            anchor: Some(anchor.into()),
+            elements: Vec::new(),
+        }
+    }
+
     /// Const constructor used for statics.
     pub const fn const_new() -> Self {
         Sequence {

--- a/tests/test_value_helpers.rs
+++ b/tests/test_value_helpers.rs
@@ -82,3 +82,17 @@ fn test_sequence_default() {
     assert!(seq.elements.is_empty());
     assert_eq!(seq, Sequence::new());
 }
+
+#[test]
+fn test_sequence_with_anchor() {
+    let seq = Sequence::with_anchor("anchor");
+    assert_eq!(seq.anchor.as_deref(), Some("anchor"));
+    assert!(seq.elements.is_empty());
+}
+
+#[test]
+fn test_mapping_with_anchor() {
+    let map = Mapping::with_anchor("anchor");
+    assert_eq!(map.anchor.as_deref(), Some("anchor"));
+    assert!(map.is_empty());
+}


### PR DESCRIPTION
## Summary
- allow creating `Sequence` instances with an anchor via `Sequence::with_anchor`
- add `Mapping::with_anchor` constructor for anchored maps
- test new constructors for anchors

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c47d4571fc832ca16c7e25d42073ec