### PR TITLE
Add multi-document deserialization helpers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,32 +268,34 @@
 )]
 
 pub use crate::de::{
-    from_reader, from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi,
-    from_str_value, from_str_value_preserve, digits_but_not_number, parse_bool_casefold, parse_f64,
-    Deserializer, StreamDeserializer, DeserializerOptions
+    digits_but_not_number, from_multiple, from_multiple_with_options, from_reader,
+    from_reader_multi, from_slice, from_slice_multi, from_str, from_str_multi, from_str_value,
+    from_str_value_preserve, parse_bool_casefold, parse_f64, Deserializer, DeserializerOptions,
+    DuplicateKeyStrategy, MultiDocumentInput, StreamDeserializer,
 };
 pub use crate::error::{Error, Location, Result};
-pub use crate::ser::{
-    to_string, to_string_multi, to_writer, to_writer_multi, FlowSeq, FlowMap, Serializer, SerializerBuilder,
-};
 pub use crate::libyaml::emitter::SequenceStyle;
+pub use crate::ser::{
+    to_string, to_string_multi, to_writer, to_writer_multi, FlowMap, FlowSeq, Serializer,
+    SerializerBuilder,
+};
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Number, Sequence, Value};
 
 #[doc(inline)]
 pub use crate::mapping::Mapping;
 
+pub mod budget;
 mod de;
+mod duplicate_key;
 mod error;
 mod libyaml;
 mod loader;
 pub mod mapping;
-mod duplicate_key;
 mod number;
 mod path;
 mod ser;
 pub mod value;
-pub mod budget;
 
 pub use crate::number::unexpected;
 
@@ -306,4 +308,3 @@ mod private {
     impl Sealed for crate::Value {}
     impl<T> Sealed for &T where T: ?Sized + Sealed {}
 }
-

--- a/tests/test_multi_helpers.rs
+++ b/tests/test_multi_helpers.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use indoc::indoc;
+use serde::{Deserialize, Serialize};
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Point {
@@ -11,6 +12,49 @@ fn test_from_str_multi() {
     let yaml = indoc!("---\nx: 1\n---\nx: 2\n");
     let points: Vec<Point> = serde_yaml_bw::from_str_multi(yaml).unwrap();
     assert_eq!(points, vec![Point { x: 1 }, Point { x: 2 }]);
+}
+
+#[test]
+fn test_from_multiple_str() {
+    let yaml = indoc!("---\nx: 1\n---\nx: 2\n");
+    let points: Vec<Point> = serde_yaml_bw::from_multiple(yaml).unwrap();
+    assert_eq!(points, vec![Point { x: 1 }, Point { x: 2 }]);
+}
+
+#[test]
+fn test_from_multiple_reader() {
+    let yaml = b"---\nx: 3\n---\nx: 4\n";
+    let cursor = Cursor::new(&yaml[..]);
+    let de = serde_yaml_bw::Deserializer::from_reader(cursor);
+    let points: Vec<Point> = serde_yaml_bw::from_multiple(de).unwrap();
+    assert_eq!(points, vec![Point { x: 3 }, Point { x: 4 }]);
+}
+
+#[test]
+fn test_from_multiple_with_options_recursion_limit() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Nested {
+        values: Vec<Vec<i32>>,
+    }
+
+    let yaml = indoc!("---\nvalues:\n  - - 1\n");
+
+    let nested: Vec<Nested> = serde_yaml_bw::from_multiple(yaml).unwrap();
+    assert_eq!(
+        nested,
+        vec![Nested {
+            values: vec![vec![1]]
+        }]
+    );
+
+    let mut options = serde_yaml_bw::DeserializerOptions::default();
+    options.recursion_limit = 1;
+
+    let err = serde_yaml_bw::from_multiple_with_options::<_, Nested>(yaml, &options).unwrap_err();
+    assert!(
+        err.to_string().contains("recursion"),
+        "unexpected error message: {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a reusable `MultiDocumentInput` trait and helper routines for collecting multiple YAML documents into a `Vec<T>`
- expose the new helpers, duplicate-key strategy, and trait from the crate root
- extend multi-document tests to cover the new helpers and custom deserializer options

## Testing
- cargo build
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d6f619bce8832cac0048ff511a00f5